### PR TITLE
Fixes #331: adds ko and da to translate.ini

### DIFF
--- a/databags/translate.ini
+++ b/databags/translate.ini
@@ -115,10 +115,12 @@ missing_translations = The following pages are missing a translation
 ; Languages
 english = English
 arabic = العَرَبِيَّة
+danish = Danish
 portuguese = Português
 chinese = 漢語
 german = Deutsche
 spanish = Español
+korean = 한국어
 
 [ar]
 
@@ -238,19 +240,47 @@ missing_translations = الصفحات التالية تفتقد إلى التر�
 ; Languages
 english = English
 arabic = العَرَبِيَّة
+danish = Danish
 portuguese = Português
 chinese = 漢語
 german = Deutsche
 spanish = Español
+korean = 한국어
 
 [de]
 ; Languages
 english = English
 arabic = العَرَبِيَّة
+danish = Danish
 portuguese = Português
 chinese = 漢語
 german = Deutsche
 spanish = Español
+korean = 한국어
+
+[da]
+; Languages
+english = English
+danish = Danish
+arabic = العَرَبِيَّة
+danish = Danish
+portuguese = Português
+chinese = 漢語
+german = Deutsche
+spanish = Español
+korean = 한국어
+
+[ko]
+; Languages
+english = English
+danish = Danish
+arabic = العَرَبِيَّة
+danish = Danish
+portuguese = Português
+chinese = 漢語
+german = Deutsche
+spanish = Español
+korean = 한국어
 
 [pt]
 ; Breadcrumbs
@@ -369,10 +399,12 @@ missing_translations = As páginas a seguir não possuem tradução
 ; Languages
 english = English
 arabic = العَرَبِيَّة
+danish = Danish
 portuguese = Português
 chinese = 漢語
 german = Deutsche
 spanish = Español
+korean = 한국어
 
 [zh]
 before_link_text = 這個頁面的內容尚未翻譯完成。請協助
@@ -383,10 +415,12 @@ incomplete_space_before_link = false
 ; Languages
 english = English
 arabic = العَرَبِيَّة
+danish = Danish
 portuguese = Português
 chinese = 漢語
 german = Deutsche
 spanish = Español
+korean = 한국어
 
 [es]
 ; Breadcrumbs
@@ -505,7 +539,10 @@ outdated_translations = Las siguientes páginas pueden contener traducciones des
 ; Languages
 english = English
 arabic = العَرَبِيَّة
+danish = Danish
 portuguese = Português
 chinese = 漢語
 german = Deutsche
 spanish = Español
+korean = 한국어
+


### PR DESCRIPTION
I'm not sure if "Danish" is proper reference in Danish to the Danish language, but it's better than "None."  Also, the same issue occurred with Korean; fixed this as well.