### PR TITLE
How to use beeware will lead user to tutorial/getting_started

### DIFF
--- a/content/project/projects/tools/briefcase/contents+ar.lr
+++ b/content/project/projects/tools/briefcase/contents+ar.lr
@@ -28,8 +28,8 @@ Broadly supports Python 3. Note: exact versions supported vary depending on the 
 
 Start learning Briefcase with the `Getting Started`_ guide, or jump right in with our `Quickstart`_.
 
-.. _Getting Started: https://briefcase.readthedocs.io/en/latest/background/getting-started.html
-.. _Quickstart: https://briefcase.readthedocs.io/en/latest/tutorial/quickstart.html
+.. _Getting Started: https://briefcase.readthedocs.io/en/latest/tutorial/getting-started.html
+.. _Quickstart: https://briefcase.readthedocs.io/en/latest/background/quickstart.html
 
 ---
 help_required:

--- a/content/project/projects/tools/briefcase/contents+ar.lr
+++ b/content/project/projects/tools/briefcase/contents+ar.lr
@@ -29,7 +29,7 @@ Broadly supports Python 3. Note: exact versions supported vary depending on the 
 Start learning Briefcase with the `Getting Started`_ guide, or jump right in with our `Quickstart`_.
 
 .. _Getting Started: https://briefcase.readthedocs.io/en/latest/background/getting-started.html
-.. _Quickstart: https://briefcase.readthedocs.io/en/latest/background/quickstart.html
+.. _Quickstart: https://briefcase.readthedocs.io/en/latest/tutorial/quickstart.html
 
 ---
 help_required:

--- a/content/project/projects/tools/briefcase/contents+es.lr
+++ b/content/project/projects/tools/briefcase/contents+es.lr
@@ -28,7 +28,7 @@ Soporta ampliamente Python 3. Nota: las versiones exactas compatibles varían de
 
 Comienza a aprender Briefcase con la guía `Primeros pasos`_, o entra directamente a nuestra `Guía rápida`_.
 
-.. _Primeros pasos: https://briefcase.readthedocs.io/en/latest/background/getting-started.html
+.. _Primeros pasos: https://briefcase.readthedocs.io/en/latest/tutorial/getting-started.html
 .. _Guía rápida: https://briefcase.readthedocs.io/en/latest/background/quickstart.html
 ---
 help_required:

--- a/content/project/projects/tools/briefcase/contents.lr
+++ b/content/project/projects/tools/briefcase/contents.lr
@@ -28,7 +28,7 @@ Broadly supports Python 3. Note: exact versions supported vary depending on the 
 
 Start learning Briefcase with the `Getting Started`_ guide, or jump right in with our `Quickstart`_.
 
-.. _Getting Started: https://briefcase.readthedocs.io/en/latest/background/getting-started.html
+.. _Getting Started: https://briefcase.readthedocs.io/en/latest/tutorial/getting-started.html
 .. _Quickstart: https://briefcase.readthedocs.io/en/latest/background/quickstart.html
 
 ---

--- a/content/project/using/android-app/contents+es.lr
+++ b/content/project/using/android-app/contents+es.lr
@@ -14,7 +14,7 @@ VOC también le permite acceder a los objetos Java nativos como si fueran objeto
 
 Una vez que hayas escrito tu aplicación de Android nativa, puedes usar `Briefcase`_ para empaquetar tu código de Python como una aplicación de Android. Briefcase toma la definición de `setup.py` de distutils para su proyecto de Python, y usa esos metadatos para generar un proyecto base de Android, compilar su código de Python y colocar los artefactos compilados para que se encuentren cuando ejecute su proyecto de Android. El proyecto de stub se genera utilizando la `Plantilla Python para Android`_.
 
-Sigue el tutorial `en los documentos de Briefcase <https://briefcase.readthedocs.io/en/latest/tutorial/tutorial-0.html>`__ para empezar!
+Sigue el tutorial `en los documentos de Briefcase <https://briefcase.readthedocs.io/en/latest/tutorial/getting-started.html>`__ para empezar!
 
 .. _VOC: /es/proyecto/proyectos/puentes/voc
 .. _Briefcase: /es/proyecto/proyectos/herramientas/briefcase

--- a/content/project/using/android-app/contents.lr
+++ b/content/project/using/android-app/contents.lr
@@ -14,7 +14,7 @@ VOC also allows you to access native Java objects as if they were Python objects
 
 Once you've written your native Android application, you can use `Briefcase`_ to package your Python code as an Android application. Briefcase takes the distutils `setup.py` definition for your Python project, and uses that metadata to generate a stub Android project, compile your Python code, and place the compiled artefacts so that they will be found when you run your Android project. The stub project is generated using the `Python Android template`_.
 
-Follow the `tutorial in the briefcase docs <https://briefcase.readthedocs.io/en/latest/tutorial/tutorial-0.html>`__ to get started!
+Follow the `tutorial in the briefcase docs <https://briefcase.readthedocs.io/en/latest/tutorial/getting-started.html>`__ to get started!
 
 .. _VOC: /project/projects/bridges/voc
 .. _Briefcase: /project/projects/tools/briefcase

--- a/content/project/using/cross-platform-mobile/contents+es.lr
+++ b/content/project/using/cross-platform-mobile/contents+es.lr
@@ -14,7 +14,7 @@ Esta API utiliza las capacidades de `Rubicon`_ y `VOC`_ para acceder a bibliotec
 
 Una vez que hayas escrito tu aplicación móvil, puedes usar `Briefcase`_ para empaquetar tu código Python para plataformas específicas. Briefcase toma la definición de `config.py` de distutils para tu proyecto de Python, y usa esa metadata para generar un proyecto de iOS o Android, compilar tu código de Python y ubicar los artefactos compilados para que se encuentren cuando se ejecute la aplicación. El proyecto de base se genera utilizando la  `Plantilla Python para iOS`_ y la `Plantilla Python para Android`_.
 
-Sigue el tutorial `en los documentos de Briefcase <https://briefcase.readthedocs.io/en/latest/tutorial/tutorial-0.html>`__ para empezar!
+Sigue el tutorial `en los documentos de Briefcase <https://briefcase.readthedocs.io/en/latest/tutorial/getting-started.html>`__ para empezar!
 
 .. _Toga: /es/proyecto/proyectos/librerias/toga
 .. _Rubicon: /es/proyecto/proyectos/puentes/rubicon

--- a/content/project/using/cross-platform-mobile/contents.lr
+++ b/content/project/using/cross-platform-mobile/contents.lr
@@ -14,7 +14,7 @@ This API uses the capabilities of `Rubicon`_ and `VOC`_ to access native system 
 
 Once you've written your mobile application, you can use `Briefcase`_ to package your Python code for specific platforms. Briefcase takes the distutils `setup.py` definition for your Python project, and uses that metadata to generate a stub iOS or Android project, compile your Python code, and place the compiled artefacts so that they will be found when you run the app. The stub project is generated using the `Python iOS template`_ and `Python Android template`_.
 
-Follow the `tutorial in the briefcase docs <https://briefcase.readthedocs.io/en/latest/tutorial/tutorial-0.html>`__ to get started!
+Follow the `tutorial in the briefcase docs <https://briefcase.readthedocs.io/en/latest/tutorial/getting-started.html>`__ to get started!
 
 .. _Toga: /project/projects/libraries/toga
 .. _Rubicon: /project/projects/bridges/rubicon

--- a/content/project/using/desktop-app/contents+es.lr
+++ b/content/project/using/desktop-app/contents+es.lr
@@ -14,7 +14,7 @@ En macOS, esta API utiliza las capacidades de `Rubicon`_ para acceder a bibliote
 
 Una vez que hayas escrito tu aplicación móvil, puedes usar `Briefcase`_ para empaquetar tu código Python para plataformas específicas. Briefcase toma la definición de `setup.py` de distutils para tu proyecto de Python, y usa esa metadata para generar un proyecto de base, compilar tu código Python y ubicar los artefactos compilados para que se encuentren cuando ejecute la aplicación. El proyecto de base se genera usando la `Plantilla Python para macOS`_.
 
-Sigue el tutorial `en los documentos de Briefcase <https://briefcase.readthedocs.io/en/latest/tutorial/tutorial-0.html>`__ para empezar!
+Sigue el tutorial `en los documentos de Briefcase <https://briefcase.readthedocs.io/en/latest/tutorial/getting-started.html>`__ para empezar!
 
 .. _Toga: /es/proyecto/proyectos/librerias/toga
 .. _Rubicon: /es/proyecto/proyectos/puentes/rubicon

--- a/content/project/using/desktop-app/contents.lr
+++ b/content/project/using/desktop-app/contents.lr
@@ -14,7 +14,7 @@ On macOS, this API uses the capabilities of `Rubicon`_ to access native system l
 
 Once you've written your desktop application, you can use `Briefcase`_ to package your Python code for specific platforms. Briefcase takes the distutils `setup.py` definition for your Python project, and uses that metadata to generate a stub project, compile your Python code, and place the compiled artefacts so that they will be found when you run the app. The stub project is generated using the `Python macOS template`_.
 
-Follow the `tutorial in the briefcase docs <https://briefcase.readthedocs.io/en/latest/tutorial/tutorial-0.html>`__ to get started!
+Follow the `tutorial in the briefcase docs <https://briefcase.readthedocs.io/en/latest/tutorial/getting-started.html>`__ to get started!
 
 .. _Toga: /project/projects/libraries/toga
 .. _Rubicon: /project/projects/bridges/rubicon

--- a/content/project/using/ios-app/contents+es.lr
+++ b/content/project/using/ios-app/contents+es.lr
@@ -14,7 +14,7 @@ Sin embargo, no es mucho el poder ser capaz de ejecutar código Python si no pue
 
 Una vez que hayas escrito tu aplicación nativa de iOS, puedes utilizar `Briefcase`_ para empaquetar el código Python como un paquete de aplicaciones de iOS. Briefcase toma la definición `config.py` de `distutils` para tu proyecto Python y usa esa metadata para generar un proyecto base de Xcode para iOS, y agrega tu código Python y las dependencias para que se encuentren cuando ejecutes tu proyecto iOS. El proyecto de base se genera utilizando la `Plantilla Python para iOS`_.
 
-Sigue el tutorial `en los documentos de Briefcase <https://briefcase.readthedocs.io/en/latest/tutorial/tutorial-0.html>`__ para empezar!
+Sigue el tutorial `en los documentos de Briefcase <https://briefcase.readthedocs.io/en/latest/tutorial/getting-started.html>`__ para empezar!
 
 .. _Soporte Python para Apple: /es/proyecto/proyectos/soporte/soporte-python-apple
 .. _Rubicon: /es/proyecto/proyectos/puentes/rubicon

--- a/content/project/using/ios-app/contents.lr
+++ b/content/project/using/ios-app/contents.lr
@@ -14,7 +14,7 @@ However, it's not much use being able to run Python code if you can't access sys
 
 Once you've written your native iOS application, you can use `Briefcase`_ to package your Python code as an iOS application bundle. Briefcase takes the distutils `setup.py` definition for your Python project, and uses that metadata to generate a stub iOS Xcode project, and add your Python code and dependencies so that they will be found when you run your iOS project. The stub project is generated using the `Python iOS template`_.
 
-Follow the `tutorial in the briefcase docs <https://briefcase.readthedocs.io/en/latest/tutorial/tutorial-0.html>`__ to get started!
+Follow the `tutorial in the briefcase docs <https://briefcase.readthedocs.io/en/latest/tutorial/getting-started.html>`__ to get started!
 
 .. _Python Apple support: /project/projects/support/python-apple-support
 .. _Rubicon: /project/projects/bridges/rubicon


### PR DESCRIPTION
Each 'how to use beeware' scenario/project will lead user to `Getting Started` page from briefcase tutorial section (this PR requires https://github.com/beeware/briefcase/pull/231 to be merged first)