### PR TITLE
Link to the first step of the briefcase tutorial

### DIFF
--- a/content/project/using/desktop-app/contents.lr
+++ b/content/project/using/desktop-app/contents.lr
@@ -14,7 +14,7 @@ On macOS, this API uses the capabilities of `Rubicon`_ to access native system l
 
 Once you've written your desktop application, you can use `Briefcase`_ to package your Python code for specific platforms. Briefcase takes the distutils `setup.py` definition for your Python project, and uses that metadata to generate a stub project, compile your Python code, and place the compiled artefacts so that they will be found when you run the app. The stub project is generated using the `Python macOS template`_.
 
-Follow the `tutorial in the briefcase docs <https://briefcase.readthedocs.io/en/latest/tutorial/tutorial-0.html>`__ to get started!
+Follow the `tutorial in the briefcase docs <https://briefcase.readthedocs.io/en/latest/tutorial/getting-started.html>`__ to get started!
 
 .. _Toga: /project/projects/libraries/toga
 .. _Rubicon: /project/projects/bridges/rubicon


### PR DESCRIPTION
In order to get started, I followed these links:

![](https://zappy.zapier.com/38996A5F-88A4-49E4-94B4-2E6ABA27DF58.png)

![](https://zappy.zapier.com/4EB71935-0E6C-4A58-B598-3C8B3E521828.png)

which takes me to "step 0" of the briefcase tutorial, which assumes I have already installed `briefcase` into a virtual environment.

Attempting to follow the instruction from this point eventually results in the following error:

```
$ python setup.py macos -s
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help

error: invalid command 'macos'
```

I think we should send people to the beginning of the briefcase tutorial.
