### PR TITLE
Toga no longer runs under Python 2

### DIFF
--- a/content/project/projects/libraries/toga/contents.lr
+++ b/content/project/projects/libraries/toga/contents.lr
@@ -40,7 +40,7 @@ Most widget toolkits start their life as a C or C++ layer, which is then wrapped
 
 Toga has been designed from the ground up to be a Python native widget toolkit. This means the API is able to exploit language level features like generators and context managers in a way that a wrapper around a C library wouldn’t be able to (at least, not easily).
 
-This also means supporting Python 3. Toga supports both Python 2 and Python 3, in a unified codebase by following established conventions.
+Toga runs on Python 3. It does not run on Python 2.
 
 *pip install and nothing more*
 


### PR DESCRIPTION
The documentation stated, incorrectly, that Toga supports both Python 2 and 3, under a unified codebase. @freakboy3742 tells me this is no longer true, so I have updated the documentation here to reflect that.