### PR TITLE
Specify that android is already supported.

### DIFF
--- a/content/project/projects/tools/briefcase/contents.lr
+++ b/content/project/projects/tools/briefcase/contents.lr
@@ -19,8 +19,8 @@ application. You can package projects for:
 * Windows
 * Linux
 * iPhone/iPad
-
-Support for Android, AppleTV, watchOS, wearOS and web deployments is planned.
+* Android
+Support for AppleTV, watchOS, wearOS and web deployments is planned.
 
 If you want to see Briefcase in action, try the `BeeWare tutorial
 <https://beeware.readthedocs.io>`__. That tutorial walks you through the


### PR DESCRIPTION
The current state of the [Briefcase page](https://beeware.org/project/projects/tools/briefcase/) on the website states that android is still a planned feature. However currently, android is supported. 
This PR fixes that.