### PR TITLE
Rename pybee->beeware

### DIFF
--- a/content/contributing/how/translations/contents+de.lr
+++ b/content/contributing/how/translations/contents+de.lr
@@ -7,8 +7,8 @@ body:
 Du willst mithelfen, die Inhalte dieser Website zu übersetzen oder zu aktualisieren?
 
 Diese Seiten basieren hauptsächlich auf `Lektor-Dateien (.lr) <https://www.getlektor.com/docs/content/>`__ und `.ini Data Bags <https://www.getlektor.com/docs/content/databags/>`__.
-Um eine Seite zu übersetzen, wähle die entsprechende Sprache unten aus, öffne eine Seite und klick dann auf dieser Seite oben rechts auf "Translate on GitHub".
-Um Data Bags zu übersetzen, `öffne eine .ini-Datei <https://github.com/pybee/pybee.github.io/tree/lektor/databags>`__ und erstelle oder bearbeite den Abschnitt für die entsprechende Sprache (z. B. [de] für Deutsch).
+Um eine Seite zu übersetzen, wähle die entsprechende Sprache unten aus, öffne eine Seite und klick dann auf dieser Seite oben rechts auf "Edit on GitHub".
+Um Data Bags zu übersetzen, `öffne eine .ini-Datei <https://github.com/beeware/beeware.github.io/tree/lektor/databags>`__ und erstelle oder bearbeite den Abschnitt für die entsprechende Sprache (z. B. [de] für Deutsch).
 
 Einige Seiten dieser Website sind aktuell in den folgenden Sprachen verfügbar:
 

--- a/content/contributing/how/translations/contents+de.lr
+++ b/content/contributing/how/translations/contents+de.lr
@@ -7,7 +7,7 @@ body:
 Du willst mithelfen, die Inhalte dieser Website zu übersetzen oder zu aktualisieren?
 
 Diese Seiten basieren hauptsächlich auf `Lektor-Dateien (.lr) <https://www.getlektor.com/docs/content/>`__ und `.ini Data Bags <https://www.getlektor.com/docs/content/databags/>`__.
-Um eine Seite zu übersetzen, wähle die entsprechende Sprache unten aus, öffne eine Seite und klick dann auf dieser Seite oben rechts auf "Edit on GitHub".
+Um eine Seite zu übersetzen, wähle die entsprechende Sprache unten aus, öffne eine Seite und klick dann auf dieser Seite oben rechts auf "Translate on GitHub".
 Um Data Bags zu übersetzen, `öffne eine .ini-Datei <https://github.com/beeware/beeware.github.io/tree/lektor/databags>`__ und erstelle oder bearbeite den Abschnitt für die entsprechende Sprache (z. B. [de] für Deutsch).
 
 Einige Seiten dieser Website sind aktuell in den folgenden Sprachen verfügbar:


### PR DESCRIPTION
updated the naming pybee to beeware and did a small correction on the top-right corner "button" Edit on github

<!--- Describe your changes in detail -->
No big changes renamed the github url in the german translation and adapted a wrong description in the translation
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
