### PR TITLE
Apply workaround for lektor/lektor#1026.

### DIFF
--- a/packages/lektor_beeware_plugin/lektor_beeware_plugin.py
+++ b/packages/lektor_beeware_plugin/lektor_beeware_plugin.py
@@ -146,7 +146,7 @@ class BeeWarePlugin(Plugin):
 
             config = self.env.jinja_env.globals['config']
             site = self.env.jinja_env.globals['site']
-            primary_path = site.get(record.path).contents.filename
+            primary_path = site.get(record.path, alt="_primary").contents.filename
             primary_path = primary_path.replace(
                 '+{0}.lr'.format(config.primary_alternative), '.lr')
             try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,17 @@
-Lektor==3.3.1
+Lektor==3.3.3
 pygments==2.11.2
-# Dependencies that need to be locked for safety
+# Pinned dependencies.
+# These are pinned because they're versions that are known to work
 Babel==2.9.1
 charset-normalizer==2.0.12
 click==8.1.2
-ExifRead==2.3.2
+EXIFRead==2.3.2
 filetype==1.0.10
 Flask==2.1.1
 idna==3.3
 inifile==0.4.1
 itsdangerous==2.1.2
 Jinja2==3.1.1
-Lektor==3.3.1
 MarkupSafe==2.1.1
 mistune==0.8.4
 python-slugify==6.1.1
@@ -19,4 +19,4 @@ requests==2.27.1
 text-unidecode==1.3
 urllib3==1.26.9
 watchdog==2.1.7
-Werkzeug==2.0.3
+Werkzeug==2.1.1

--- a/templates/home.html
+++ b/templates/home.html
@@ -124,7 +124,7 @@
     {% for project_type in project_types %}
     {%   for project in site.query(project_type.path, alt=this.alt).filter(F.showcase==True) %}
     <div>
-      <h4><a href="{{ project|url(alt=this.alt) }}"><img src="{{ site.get(project.path)|url }}{{ project.image }}" height="32px" alt="{{ project.name }}"> {{ project.name }}</h4></a>
+      <h4><a href="{{ project|url(alt=this.alt) }}"><img src="{{ site.get(project.path, alt='_primary')|url }}{{ project.image }}" height="32px" alt="{{ project.name }}"> {{ project.name }}</h4></a>
       {{ project.short_description|safe }}
     </div>
     {%   endfor %}
@@ -201,7 +201,7 @@
     {% for project_type in project_types %}
     {%   for project in site.query(project_type.path, alt=this.alt).filter(F.showcase==True) %}
     <div>
-      <h4><a href="{{ project|url(alt=this.alt) }}"><img src="{{ site.get(project.path)|url }}{{ project.image }}" height="32px" alt="{{ project.name }}"> {{ project.name }}</h4></a>
+      <h4><a href="{{ project|url(alt=this.alt) }}"><img src="{{ site.get(project.path, alt='_primary')|url }}{{ project.image }}" height="32px" alt="{{ project.name }}"> {{ project.name }}</h4></a>
       {{ project.short_description|safe }}
     </div>
     {%   endfor %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -102,7 +102,7 @@
           </a>
           {%- else -%}
           {# This method is provided by a custom plugin found in /packages/lektor_beeware_plugin/ #}
-          {%- set content_value = urlencode_limit(site.get(this.path).contents.as_text(), limit=5000) -%}
+          {%- set content_value = urlencode_limit(site.get(this.path, alt='_primary').contents.as_text(), limit=5000) -%}
           {%- if content_value and '@' not in this.path -%}
           <a class="nav-link" href="https://github.com/beeware/beeware.github.io/new/lektor/content{{ this.path }}/contents{{ alt_path }}.lr?filename=contents{{ alt_path }}.lr&value={{ content_value }}" target="_blank">
             <i class="fa fa-github "></i><small>&nbsp;{{ t_create_on_github }}</small>
@@ -141,7 +141,7 @@
         {%- if this.alt in get_alts(source=this, fallback=False) and diff -%}
         <div class="alert alert-warning">
           <i class="fa fa-warning"></i>&nbsp;{{ t_translation_out_of_date }}&nbsp;&nbsp;
-          <a href="{{ site.get(this.path)|url }}" data-toggle="modal" data-target="#myModal">{{ t_see_original_content }}</a>
+          <a href="{{ site.get(this.path, alt='_primary')|url }}" data-toggle="modal" data-target="#myModal">{{ t_see_original_content }}</a>
         </div>
 
         <!-- Modal -->

--- a/templates/member.html
+++ b/templates/member.html
@@ -12,8 +12,8 @@
   <div class="container">
     <p>{{ breadcrumbs(this) }}</p>
     <h2>{{ sponsorship_level(this) }}</h2>
-    {% if this.image %} 
-    <a href="{{ this|url }}"><img src="{{ site.get(this.path)|url }}{{ this.image }}"></a>
+    {% if this.image %}
+    <a href="{{ this|url }}"><img src="{{ site.get(this.path, alt='_primary')|url }}{{ this.image }}"></a>
     {% endif %}
     {% if this.level == "historical" %}
     <p class="period">{{ this.join_date.strftime("%B %Y") }} - {{ this.end_date.strftime("%B %Y") }}

--- a/templates/members.html
+++ b/templates/members.html
@@ -20,7 +20,7 @@
     <h2>Gold Members</h2>
   {% for member in members %}
     {% if member.image %}
-    <a href="{{ member|url(alt=this.alt) }}"><img class="img-fluid" src="{{ site.get(member.path)|url }}{{ member.image }}" alt="{{ member.name }}"></a>
+    <a href="{{ member|url(alt=this.alt) }}"><img class="img-fluid" src="{{ site.get(member.path, alt='_primary')|url }}{{ member.image }}" alt="{{ member.name }}"></a>
     {% endif %}
     <p>{{ member.description }}</p>
   {% endfor %}
@@ -31,7 +31,7 @@
     <h2>Silver Members</h2>
   {% for member in members %}
     {% if member.image %}
-    <a href="{{ member|url(alt=this.alt) }}"><img class="img-fluid" src="{{ site.get(member.path)|url }}{{ member.image }}" alt="{{ member.name }}"></a>
+    <a href="{{ member|url(alt=this.alt) }}"><img class="img-fluid" src="{{ site.get(member.path, alt='_primary')|url }}{{ member.image }}" alt="{{ member.name }}"></a>
     {% endif %}
     <p>{{ member.description }}</p>
   {% endfor %}
@@ -42,7 +42,7 @@
     <h2>Bronze Members</h2>
   {% for member in members %}
     {% if member.image_small %}
-    <a href="{{ member|url(alt=this.alt) }}"><img class="img-fluid" src="{{ site.get(member.path)|url }}{{ member.image_small }}" alt="{{ member.name }}"></a>
+    <a href="{{ member|url(alt=this.alt) }}"><img class="img-fluid" src="{{ site.get(member.path, alt='_primary')|url }}{{ member.image_small }}" alt="{{ member.name }}"></a>
     {% endif %}
     <p>{{ member.description }}</p>
   {% endfor %}
@@ -53,7 +53,7 @@
     <h2>AdHoc Members</h2>
   {% for member in members %}
     {% if member.image_small %}
-    <a href="{{ member|url(alt=this.alt) }}"><img class="img-fluid" src="{{ site.get(member.path)|url }}{{ member.image_small }}" alt="{{ member.name }}"></a>
+    <a href="{{ member|url(alt=this.alt) }}"><img class="img-fluid" src="{{ site.get(member.path, alt='_primary')|url }}{{ member.image_small }}" alt="{{ member.name }}"></a>
     {% endif %}
     <p>{{ member.description }}</p>
       {% if member.contribution %}
@@ -87,7 +87,7 @@
   <h2>In-Kind Members</h2>
   {% for member in members %}
     {% if member.image_small %}
-    <a href="{{ member|url(alt=this.alt) }}"><img class="img-fluid" src="{{ site.get(member.path)|url }}{{ member.image_small }}" alt="{{ member.name }}"></a>
+    <a href="{{ member|url(alt=this.alt) }}"><img class="img-fluid" src="{{ site.get(member.path, alt='_primary')|url }}{{ member.image_small }}" alt="{{ member.name }}"></a>
     {% endif %}
       {% if member.contribution %}
     <p>{{ member.contribution }}</p>


### PR DESCRIPTION
Lektor 3.3.2 introduced a change to how the default alternative is computed; this caused a problem preventing a clean up date.

Following [this suggestion](https://github.com/lektor/lektor/issues/1026#issuecomment-1089773345), we can now upgrade to 3.3.3.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
