### PR TITLE
Two more workarounds missed in #473.

### DIFF
--- a/templates/project-type.html
+++ b/templates/project-type.html
@@ -17,8 +17,8 @@
     {% for child in this.children %}
     <div class="clearfix project">
     {% if child.image %}
-      <img src="{{ site.get(child.path)|url }}{{ child.image }}" height="72px" class="pull-xs-left">
-    {% else %} 
+      <img src="{{ site.get(child.path, alt='_primary')|url }}{{ child.image }}" height="72px" class="pull-xs-left">
+    {% else %}
       <img src="/static/images/defaultlogo.png" height="72px" class="pull-xs-left">
     {% endif %}
       <h2><a href="{{ child|url(alt=this.alt) }}">{{ child.name }}</a></h2>

--- a/templates/project.html
+++ b/templates/project.html
@@ -67,7 +67,7 @@
 
   <div class="col-sm-4">
     <div class="sidebar-module sidebar-module-inset gutter">
-    <img class="img-fluid center-block" {% if this.image %}src="{{ site.get(this.path)|url }}{{ this.image }}" {% else %} src="/static/images/defaultlogo.png"{% endif %}></div>
+    <img class="img-fluid center-block" {% if this.image %}src="{{ site.get(this.path, alt='_primary')|url }}{{ this.image }}" {% else %} src="/static/images/defaultlogo.png"{% endif %}></div>
     {% if this.github_repo or this.rtfd_name %}<br />{% endif %}
     {% if this.github_repo %}<p><a href="https://github.com/{{ this.github_repo }}"><i class="fa fa-github fa-lg" aria-hidden="true"></i> {{ t_source_code }}</a></p>{% endif %}
     {% if this.rtfd_name %}<p><a href="https://{{ this.rtfd_name }}.readthedocs.io/"><i class="fa fa-book fa-lg" aria-hidden="true"></i> {{ t_documentation }}</a></p>{% endif %}


### PR DESCRIPTION
Two more site.get() workarounds missed in the original patch for #473.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
