### PR TITLE
Show the logo in the header on smaller screens

### DIFF
--- a/assets/static/beeware.css
+++ b/assets/static/beeware.css
@@ -63,6 +63,12 @@
 /* Small devices (landscape phones, less than 48em) */
 @media (max-width: 768px) {
 
+  .navbar-brand-block{
+    position: absolute;
+    margin-top: -40px;
+    right: 10px;
+  }
+
   .beeware-logo {
     display: block;
     margin: 15px 0 35px;
@@ -87,6 +93,12 @@
 }
 /* Extra small devices (portrait phones, less than 34em) */
 @media (max-width: 544px) {
+
+  .navbar-brand-block{
+    position: absolute;
+    margin-top: -40px;
+    right: 10px;
+  }
 
   .beeware-logo {
     display: block;

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -76,9 +76,9 @@
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsDefault" aria-controls="navbarsDefault" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
+    <div class="navbar-brand-block"><a class="navbar-brand" href="{{ '/'|url(alt=this.alt) }}">BeeWare</a></div>
   </div>
   <div class="collapse navbar-collapse" id="navbarsDefault">
-    <div class="navbar-brand-block"><a class="navbar-brand" href="{{ '/'|url(alt=this.alt) }}">BeeWare</a></div>
     <ul class="navbar-nav mr-auto">
       {{ menu_item('project') }}
       {{ menu_item('news') }}


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Made the logo visible in the header on mobile and smaller screens. (See imgages below)
<!--- What problem does this change solve? -->
Makes it more clear what page you are on by showing the logo on smaller screens aswell instead of in the menu.

New
<img src="https://user-images.githubusercontent.com/39992041/202867663-bdcdade2-68eb-4d7b-bb1e-920aa33ad1a3.png" width="400" />
Old
<img src="https://user-images.githubusercontent.com/39992041/202867665-a3561dfb-3028-4e6a-bfa2-8e150ce6a0fb.jpg" width="400" />

p.s This is my first pull request ever!

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct

