### PR TITLE
Show the logo in the header(navbar) on smaller screens. Brutus logo added.

### DIFF
--- a/assets/static/beeware.css
+++ b/assets/static/beeware.css
@@ -44,7 +44,7 @@
   .beeware-logo {
     display: block;
     margin: 15px 0 35px;
-    width: 30%;
+    width: 25%;
   }
 
   .display-1 {
@@ -72,7 +72,7 @@
   .beeware-logo {
     display: block;
     margin: 15px 0 35px;
-    width: 30%;
+    width: 50%;
   }
 
   .display-1 {

--- a/assets/static/beeware.css
+++ b/assets/static/beeware.css
@@ -44,7 +44,7 @@
   .beeware-logo {
     display: block;
     margin: 15px 0 35px;
-    width: 25%;
+    width: 30%;
   }
 
   .display-1 {
@@ -72,7 +72,7 @@
   .beeware-logo {
     display: block;
     margin: 15px 0 35px;
-    width: 50%;
+    width: 30%;
   }
 
   .display-1 {
@@ -93,12 +93,6 @@
 }
 /* Extra small devices (portrait phones, less than 34em) */
 @media (max-width: 544px) {
-
-  .navbar-brand-block{
-    position: absolute;
-    margin-top: -40px;
-    right: 10px;
-  }
 
   .beeware-logo {
     display: block;
@@ -155,9 +149,10 @@
   }
 
   .navbar-brand-block {
-    border-bottom: 1px solid #666;
+    position: absolute;
+    margin-top: -40px;
     padding: 0 1em 0.2em;
-    width: 100%;
+    right: 10px;
   }
 
   .navbar-collapse {

--- a/assets/static/beeware.css
+++ b/assets/static/beeware.css
@@ -63,6 +63,12 @@
 /* Small devices (landscape phones, less than 48em) */
 @media (max-width: 768px) {
 
+  .navbar-brand-block{
+    position: absolute;
+    margin-top: -40px;
+    right: 10px;
+  }
+
   .beeware-logo {
     display: block;
     margin: 15px 0 35px;
@@ -87,6 +93,12 @@
 }
 /* Extra small devices (portrait phones, less than 34em) */
 @media (max-width: 544px) {
+
+  .navbar-brand-block{
+    position: absolute;
+    margin-top: -40px;
+    right: 10px;
+  }
 
   .beeware-logo {
     display: block;

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -76,9 +76,9 @@
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsDefault" aria-controls="navbarsDefault" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
+    <div class="navbar-brand-block"><a class="navbar-brand" href="{{ '/'|url(alt=this.alt) }}">BeeWare</a></div>
   </div>
   <div class="collapse navbar-collapse" id="navbarsDefault">
-    <div class="navbar-brand-block"><a class="navbar-brand" href="{{ '/'|url(alt=this.alt) }}">BeeWare</a></div>
     <ul class="navbar-nav mr-auto">
       {{ menu_item('project') }}
       {{ menu_item('news') }}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -77,7 +77,7 @@
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="navbar-brand-block">
-      <a class="navbar-brand" href="{{ '/'|url(alt=this.alt) }}">BeeWare<img class="mx-1" src="{{ '/static/images/brutus-32.png'|asseturl }}"></a>
+      <a class="navbar-brand" href="{{ '/'|url(alt=this.alt) }}"><img class="mx-2" src="{{ '/static/images/brutus-32.png'|asseturl }}">BeeWare</a>
     </div>
   </div>
   <div class="collapse navbar-collapse" id="navbarsDefault">

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -76,7 +76,9 @@
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsDefault" aria-controls="navbarsDefault" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
-    <div class="navbar-brand-block"><a class="navbar-brand" href="{{ '/'|url(alt=this.alt) }}">BeeWare</a></div>
+    <div class="navbar-brand-block">
+      <a class="navbar-brand" href="{{ '/'|url(alt=this.alt) }}">BeeWare<img class="mx-1" src="{{ '/static/images/brutus-32.png'|asseturl }}"></a>
+    </div>
   </div>
   <div class="collapse navbar-collapse" id="navbarsDefault">
     <ul class="navbar-nav mr-auto">


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Made the logo visible in the header on mobile and smaller screens. I have also added the Burtus-bee to the navbar.
<img src="https://user-images.githubusercontent.com/39992041/203138724-7c505525-77a9-44db-80c0-11c6272ea219.png" width="400"/>
<img src="https://user-images.githubusercontent.com/39992041/203139384-cc8ac6d6-aecf-4d4d-b074-39a1c2bf2b89.png" width="400"/>
<!--- What problem does this change solve? -->
Makes it more clear what page you are on by showing the logo on smaller screens as well instead of in the menu.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

This is a reupload of this PR since I show how managed to delete it [Link](https://github.com/beeware/beeware.github.io/pull/502)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
