### PR TITLE
Correct the Mastodon verification links for team members.

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -198,8 +198,10 @@
           <a href="{{ '/sitemap'|url(alt=this.alt) }}"><i class="fa fa-sitemap fa-lg" aria-hidden="true"></i> {{ t_sitemap }}</a>
         </p>
         {% set team = site.query('/community/team', alt=this.alt).all() %}
-        {% for child in team %}
-        <a rel="me" href={{ child.mastodon_handle }} style="display:none" ></a>
+        {% for member in team %}
+          {% if member.mastodon_handle %}
+        <a rel="me" href="https://{{ member.mastodon_handle.split('@')[2] }}/@{{ member.mastodon_handle.split('@')[1] }}" style="display:none" ></a>
+          {% endif %}
         {% endfor %}
       </div>
     </footer>


### PR DESCRIPTION
The mastodon verification links in the footer added in #520 weren't rendering correctly; wasn't caught in review because they're non-visible.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
