### PR TITLE
Make button row 11 columns wide at small viewports.

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -45,7 +45,7 @@
     {% for blk in this.body.blocks %}
     {% if blk._flowblock == 'button-block' %}
     <div class="row">
-      <div class="col-sm-8 col-sm-offset-2">
+      <div class="col-sm-11 col-sm-offset-2">
         {{ blk }}
       </div>
     </div>


### PR DESCRIPTION
<!--- Describe your changes in detail -->
The cause of #559 was the row the buttons are embedded in are col-sm-8, which is too thin in some breakpoints for the width of the the button. I tested a few other column widths, 10 was too thin at the 554 breakpoint. 12 is full width at all sizes. 11 works at all.

Happy to switch to 12 if that is preferred.

![image](https://github.com/beeware/beeware.github.io/assets/6393101/8ebcf32a-f1ac-421b-b89b-29cd53c76d78)

<!--- What problem does this change solve? -->
Reported as #559, the "Contribute to BeeWare" button was too narrow at a variety of breakpoints. This makes it wide enough for the text at all the major breakpoints.

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #559 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
