### PR TITLE
fix: turning community page mobile-first responsive

### DIFF
--- a/templates/community.html
+++ b/templates/community.html
@@ -2,8 +2,8 @@
 {% from "macros/breadcrumbs.html" import breadcrumbs %}
 {% block title %}{{ this.title }}{% endblock %}
 {% block gutter %}
-  
-<div class="col-sm-4">
+
+<div class="col-md-4">
   <div class="gutter">
     {{ this.gutter }}
     {% for child in this.children %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -14,7 +14,7 @@
 {% endblock %}
 {% block body %}
 <div class="row">
-  <div class="col-sm-7 mr-auto">
+  <div class="col-md-7 mr-auto">
   {{ incomplete(this) }}
   {% block main %}
     {{ this.body }}
@@ -29,13 +29,13 @@
   {% block gutter %}
     {% if this.gutter and this.gutter.source %}
   <!-- <div class="col-sm-12 col-md-4 gutter"> -->
-  <div class="col-sm-4">
+  <div class="col-md-4">
     <div class="sidebar-module sidebar-module-inset gutter">
     {{ this.gutter }}
     </div>
   </div>
     {% else %}
-  <div class="hidden-sm-down col-sm-4">
+  <div class="hidden-sm-down col-md-4">
   </div>
     {% endif %}
   {% endblock %}


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Adjusting the responsivity at the Community page.
<!--- What problem does this change solve? -->
Layout was crashing for small viewports (more specifically screens 576px up 767px wide).
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes #561

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct

**Screenshots**

_Image_

![image](https://github.com/beeware/beeware.github.io/assets/12106738/9fb52d8d-c580-484d-b10e-80940ae11e55)

_Video_

https://github.com/beeware/beeware.github.io/assets/12106738/03e475bd-c0d0-409a-b012-d8e2275358e1



