### PR TITLE
Add a shortlink for Briefcase bootstraps.

### DIFF
--- a/content/bee/briefcase-bootstraps/contents.lr
+++ b/content/bee/briefcase-bootstraps/contents.lr
@@ -1,0 +1,3 @@
+_model: redirect
+---
+new_path: https://briefcase.readthedocs.io/latest/en/reference/commands/new.html#third-party-bootstraps


### PR DESCRIPTION
Adds a shortlink so that the third-party Briefcase bootstraps can be referenced without a long URL.

Refs beeware/briefcase#1807 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
