### PR TITLE
templates: Use forkawesome as source for icons

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -53,8 +53,8 @@
       <link rel="stylesheet" type="text/css" href="/static/rtl.css">
     {%- endif -%}
 
-    <!-- Font Awesome -->
-    <script src="https://kit.fontawesome.com/078c86a30a.js" crossorigin="anonymous"></script>
+    <!-- fork awesome -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fork-awesome@1.2.0/css/fork-awesome.min.css" integrity="sha256-XoaMnoYC5TH6/+ihMEnospgm0J1PM/nioxbOUdnM8HY=" crossorigin="anonymous">
 
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-2943925-4"></script>
@@ -185,14 +185,14 @@
 	      <div class="float-right clearfix d-sm-block d-none">&copy; Russell Keith-Magee {{ none|dateformat('Y') }}</div>
         <p class="d-sm-block d-none">
           <a href="https://github.com/beeware/"><i class="fa fa-github fa-lg" aria-hidden="true"></i> GitHub</a> |
-          <a href="https://beeware.org/bee/chat/"><i class="fa-brands fa-discord fa-lg" aria-hidden="true"></i> Discord</a> |
-          <a href="https://fosstodon.org/@beeware"><i class="fa-brands fa-mastodon fa-lg" aria-hidden="true"></i> Mastodon</a> |
+          <a href="https://beeware.org/bee/chat/"><i class="fa fa-discord fa-lg" aria-hidden="true"></i> Discord</a> |
+          <a href="https://fosstodon.org/@beeware"><i class="fa fa-mastodon fa-lg" aria-hidden="true"></i> Mastodon</a> |
           <a href="{{ '/sitemap'|url(alt=this.alt) }}"><i class="fa fa-sitemap fa-lg" aria-hidden="true"></i> {{ t_sitemap }}</a>
         </p>
         <p class="d-block d-sm-none footer-social">
           <a href="https://github.com/beeware/"><i class="fa fa-github fa-lg" aria-hidden="true"></i> GitHub</a> |
-          <a href="https://beeware.org/bee/chat/"><i class="fa-brands fa-discord fa-lg" aria-hidden="true"></i> Discord</a> |
-          <a rel="me" href="https://fosstodon.org/@beeware"><i class="fa-brands fa-mastodon fa-lg" aria-hidden="true"></i> Mastodon</a>
+          <a href="https://beeware.org/bee/chat/"><i class="fa fa-discord fa-lg" aria-hidden="true"></i> Discord</a> |
+          <a rel="me" href="https://fosstodon.org/@beeware"><i class="fa fa-mastodon fa-lg" aria-hidden="true"></i> Mastodon</a>
         </p>
         <p class="d-block d-sm-none footer-sitemap">
           <a href="{{ '/sitemap'|url(alt=this.alt) }}"><i class="fa fa-sitemap fa-lg" aria-hidden="true"></i> {{ t_sitemap }}</a>

--- a/templates/macros/member-badge.html
+++ b/templates/macros/member-badge.html
@@ -7,7 +7,7 @@
   <a href="https://github.com/{{ member.github_handle }}"><i class="fa fa-github fa-lg icon" aria-hidden="true"></i>&nbsp;{{ member.github_handle }}</a>
   {% if member.mastodon_handle %}
   <br>
-  <a href="https://{{ member.mastodon_handle.split('@')[2] }}/@{{ member.mastodon_handle.split('@')[1] }}"><i class="fa-brands fa-mastodon fa-lg icon" aria-hidden="true"></i>&nbsp;{{ member.mastodon_handle }}</a>
+  <a href="https://{{ member.mastodon_handle.split('@')[2] }}/@{{ member.mastodon_handle.split('@')[1] }}"><i class="fa fa-mastodon fa-lg icon" aria-hidden="true"></i>&nbsp;{{ member.mastodon_handle }}</a>
   {% endif %}
   {% if member.twitter_handle %}
   <br>


### PR DESCRIPTION
This is a possible resolution to the issue of a "exposed fontawesome pro link" mentioned by discord user "Lord Alfred". No worries if it's not desired, I didn't understand from the short Discord discussion the impact of this problem or if this is a desirable resolution—please feel free to close this up if it's not desired.

forkawesome is a fork of fontawesome that is completely free for commercial use. For full details, see
https://forkaweso.me/Fork-Awesome/license/

forkawesome is forked from a prior version of fontawesome at a time when it was liberally licensed.

forkawesome doesn't have `fa-brands`, but discord & mastodon icons are available in the base namespace. I verified locally that these icons remain visible after my changes.

I did a quick search of all used fa- icons and I believe they are all represented in forkawesome. Additionally the fa-lg class is also supported.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
