### PR TITLE
Correct handling of previews.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'preview')
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/content/news/events/djangocon-us-2017-sprints/contents.lr
+++ b/content/news/events/djangocon-us-2017-sprints/contents.lr
@@ -1,4 +1,4 @@
-title: DjangoCon US 2017 Sprints
+title: DjangoCon US 2017
 ---
 date: 2017-08-17
 ---


### PR DESCRIPTION
PR #575 modified the GitHub checkout associated with the preview action; in doing so, it inadvertently broke previews. This is because the CI action triggers on `pull_request_target`, not `pull_request`. `pull_request_target` defaults to checking out the SHA of the branch *base*, not the head.

We have to use `pull_request_target` for security reasons; if a `pull_request` trigger is used, malicious code could alter the repository or exfiltrate secrets. 

This takes a different approach to the code removed by #575, explicitly naming the SHA of the PR branch, rather than referencing the PR as an indirect reference. Using the PR number as a proxy is potentially insecure as the PR itself could be modified.

To prove the preview is working, the PR modifies the label of the first entry on the https://beeware.org/news/events/ page. This is a change that is also made by #579.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
