### PR TITLE
Add automatic website rebuilding to this repository

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - lektor
+  repository_dispatch:
+      types:
+        - republish-request
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,5 @@
 name: Publish
+
 on:
   push:
     branches:
@@ -6,6 +7,9 @@ on:
   repository_dispatch:
       types:
         - republish-request
+
+concurrency:
+  group: ${{ github.workflow }}
 
 jobs:
   publish:

--- a/.github/workflows/trigger_republish.yml
+++ b/.github/workflows/trigger_republish.yml
@@ -6,6 +6,9 @@ on:
           - opened
           - reopened
           - transferred
+          - edited
+          - labeled
+          - unlabeled
           - closed
           - deleted
 

--- a/.github/workflows/trigger_republish.yml
+++ b/.github/workflows/trigger_republish.yml
@@ -10,7 +10,7 @@ on:
           - deleted
 
 jobs:
-    rebuid-request:
+    rebuild-request:
         runs-on: ubuntu-latest
         steps:
         - name: Submit dispatch event to BeeWare website repo

--- a/.github/workflows/trigger_republish.yml
+++ b/.github/workflows/trigger_republish.yml
@@ -1,0 +1,21 @@
+name: Trigger BeeWare website republish
+
+on:
+    issues:
+        types:
+          - opened
+          - reopened
+          - transferred
+          - closed
+          - deleted
+
+jobs:
+    rebuid-request:
+        runs-on: ubuntu-latest
+        steps:
+        - name: Submit dispatch event to BeeWare website repo
+          uses: peter-evans/repository-dispatch@v3
+          with:
+            token: ${{ secrets.REBUILD_TOKEN }}
+            repository: beeware/beeware.github.io
+            event-type: rebuild-request


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x ] All new features have been tested
- [ ] All new features have been documented
- [ x ] I have read the **CONTRIBUTING.md** file
- [ x ] I will abide by the code of conduct

Partially adds the functionality where issues being opened, edited, labeled, closed, and deleted for a given repository triggers the website rebuilding.  It works by:

- Adding a repository dispatch to this repository's publish workflow, which allows it to be triggered by other repositories.  The concurrency setting is used to make sure that only one instance is running at anytime, and at most one workflow is pending the completion of the current.  This ensures the website is continually updating even under heavy loads from multi-issue updates.  If another dispatch comes in when one is pending, the older pending run is cancelled and the new triggering workflow takes its place.
- Any sending repository must include the new `trigger_republish.yml` which is specifically is triggered.  It sends the repository dispatch event to beeware.github.io.  I have added the one this repository would use, but adding this functionality to repositories such as toga and briefcase will be necessary eventually.  **[A secret named REBUILD_TOKEN must be added to the source repository with the `repo` or `public_repo` scope](https://github.com/peter-evans/repository-dispatch?tab=readme-ov-file#token)**

This is difficult to test until it's implemented but I use this exact method myself to make sure a [repository for storing software code](https://github.com/tekktrik/CircuitPythonukiah_SW/blob/88cfd8d382eb51e07d71e76664932d2ce7985df1/.github/workflows/update.yml) triggers a pull request in the [overall project repostitory](https://github.com/tekktrik/CircuitPythonukiah/blob/main/.github/workflows/update.yml) where it is a submodule to update it.

This is the first step to creating an auto-updating issues page for the website!