### PR TITLE
Add shortlinks for tutorials.

### DIFF
--- a/content/t/code-camera/contents.lr
+++ b/content/t/code-camera/contents.lr
@@ -1,0 +1,3 @@
+_model: redirect
+---
+new_path: https://gist.github.com/freakboy3742/d3528ac8262b230480a60c0a3161f144

--- a/content/t/code/contents.lr
+++ b/content/t/code/contents.lr
@@ -1,0 +1,3 @@
+_model: redirect
+---
+new_path: https://gist.github.com/freakboy3742/64f58383864f885f535c9d0042d9f0a9

--- a/content/t/contents.lr
+++ b/content/t/contents.lr
@@ -1,0 +1,9 @@
+_model: page
+---
+title: Tutorial Shortlinks
+---
+hide_from_index: no
+---
+_discoverable: no
+---
+_hidden: no

--- a/content/t/icons/contents.lr
+++ b/content/t/icons/contents.lr
@@ -1,0 +1,3 @@
+_model: redirect
+---
+new_path: https://docs.beeware.org/en/latest/_downloads/a8f92cddc5b6e0f777b9d9b223d31cce/icons.zip

--- a/content/t/linux-deps/contents.lr
+++ b/content/t/linux-deps/contents.lr
@@ -1,0 +1,3 @@
+_model: redirect
+---
+new_path: https://gist.github.com/freakboy3742/2e3a524bf6f1cd4486bb9e7fa2a2d3fb

--- a/content/t/slides/contents.lr
+++ b/content/t/slides/contents.lr
@@ -1,0 +1,3 @@
+_model: redirect
+---
+new_path: https://www.dropbox.com/scl/fi/h6zngysnbibk3ly4e0qz9/Build-a-cross-platform-GUI-app-with-BeeWare.pdf?rlkey=knjrqcv5e6wxzv9335va0j5qu&st=t1t4ppji&dl=0

--- a/templates/redirect.html
+++ b/templates/redirect.html
@@ -1,19 +1,19 @@
 {% extends "layout.html" %}
 {% from "macros/breadcrumbs.html" import breadcrumbs %}
 
-{% block title %}Redirecting... {{ this.new_path }}{% endblock %}
+{% block title %}Redirecting... {{ this.new_path|safe }}{% endblock %}
 {% block extra_head %}
-<meta http-equiv="refresh" content="0;URL='{{ this.new_path }}" />
-<link rel="canonical" href="{{ this.new_path }}"/>
+<meta http-equiv="refresh" content="0;URL='{{ this.new_path|safe }}" />
+<link rel="canonical" href="{{ this.new_path|safe }}"/>
 <script>
-  window.location.href = "{{ this.new_path }}"
+  window.location.href = "{{ this.new_path|safe }}"
 </script>
 {% endblock %}
 {% block preamble %}
 <div class="banner">
   <div class="container">
     <h1>Redirecting...</h1>
-    <p>{{ this.new_path }}</p>
+    <p>{{ this.new_path|safe }}</p>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
I've historically used bit.ly for short links in tutorials; however, bit.ly has gone down the enshittification hole and now puts blocker ads in front of links.

Rather than switch to another shortlink service that will eventually go down the same route, I figured it's easier to host the links ourselves.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
