### PR TITLE
fix Stray 'None' in Tutorial Entries

### DIFF
--- a/databags/translate.ini
+++ b/databags/translate.ini
@@ -95,7 +95,7 @@ speaking_after_title = , giving a presentation entitled
 keynoting_before_title = will be keynoting
 keynoting_after_title = , giving a presentation entitled
 tutorial_before_title = will be presenting a tutorial at
-tutorial_ater_title = entitled
+tutorial_after_title = entitled
 sprint_helping = will be at the sprints, and will be more than willing to help First Time Contributors earn their own shiny
 sprint_helping_plural = will be at the sprints, and will be more than willing to help First Time Contributors earn their own shiny
 

--- a/templates/event.html
+++ b/templates/event.html
@@ -34,11 +34,11 @@
 {% endblock %}
 {% block main %}
 {% if this.event_type == "talk" %}
-    <p>{{ this.speaker|join(t_and)}} {{ t_speaking_before_title }} {{ this.title }}{{ t_speaking_after_title }} "<a href="{{ this.url }}">{{ this.talk_title }}</a>".
+    <p>{{ this.speaker|join(t_and)}} {{ t_speaking_before_title }} {{ this.title }} {{ t_speaking_after_title }} "<a href="{{ this.url }}">{{ this.talk_title }}</a>".
 {% elif this.event_type == "keynote" %}
-    <p>{{ this.speaker|join(t_and)}} {{ t_keynoting_before_title }} {{ this.title }}{{ t_keynoting_after_title }} "<a href="{{ this.url }}">{{ this.talk_title }}</a>".
+    <p>{{ this.speaker|join(t_and)}} {{ t_keynoting_before_title }} {{ this.title }} {{ t_keynoting_after_title }} "<a href="{{ this.url }}">{{ this.talk_title }}</a>".
 {% elif this.event_type == "tutorial" %}
-    <p>{{ this.speaker|join(t_and)}} {{ t_tutorial_before_title }} {{ this.title }}{{ t_tutorial_after_title }} "<a href="{{ this.url }}">{{ this.talk_title }}</a>".
+    <p>{{ this.speaker|join(t_and)}} {{ t_tutorial_before_title }} {{ this.title }} {{ t_tutorial_after_title }} "<a href="{{ this.url }}">{{ this.talk_title }}</a>".
 {% elif this.event_type == "sprint" %}
     <p>{{ t_running_sprint }} {{ this.title }}.</p>
   <p>{{ this.speaker|join(t_and) }} {% if this.speaker|length > 1 %}{{ t_sprint_helping_plural }}{% else %}{{ t_sprint_helping }}{% endif %} <a href="{{ '/contributing/challenge-coins/'|url(alt=this.alt) }}">{{ t_challenge_coin }}</a>.

--- a/templates/macros/translation.html
+++ b/templates/macros/translation.html
@@ -1,3 +1,3 @@
 {% macro transbag(bag_name, alt, key, alt_default='en') %}
-{{ bag(bag_name, alt, key)|default(bag(bag_name, alt_default, key), true) }}
+{{ bag(bag_name, alt, key)|default(bag(bag_name, alt_default, key), true)|default("", true)}}
 {% endmacro %}


### PR DESCRIPTION
<!--- Describe your changes in detail -->
The change is an add-on in case the default value of this line `default(bag(bag_name, alt_default, key)` fails which is what was causing the `None` entry on docs.

<!--- What problem does this change solve? -->
It eliminates having `None` on this[ issue ](https://github.com/beeware/beeware.github.io/issues/622)and on other future news entries.

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes issue [622](https://github.com/beeware/beeware.github.io/issues/622)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
