### PR TITLE
Update plugin definitions to use pyproject.toml

### DIFF
--- a/packages/lektor_atom_plugin/pyproject.toml
+++ b/packages/lektor_atom_plugin/pyproject.toml
@@ -12,7 +12,7 @@ name = "lektor-atom"
 version = "0.4.1"
 description = ""
 readme = "README.md"
-license = "GPL-MIT"
+license = "MIT"
 requires-python = ">= 3.9"
 authors = [
     {name="A. Jesse Jiryu Davis", email="jesse@emptysquare.net"},
@@ -25,7 +25,6 @@ classifiers = [
     "Environment :: Web Environment",
     "Framework :: Lektor",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
 ]
 keywords = [
     "Lektor",

--- a/packages/lektor_atom_plugin/setup.py
+++ b/packages/lektor_atom_plugin/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()

--- a/packages/lektor_beeware_plugin/pyproject.toml
+++ b/packages/lektor_beeware_plugin/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
     "Environment :: Web Environment",
     "Framework :: Lektor",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
 ]
 keywords = [
     "Lektor",

--- a/packages/lektor_beeware_plugin/setup.py
+++ b/packages/lektor_beeware_plugin/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()


### PR DESCRIPTION
The build process was raising warnings about editable installs with old setup.py definitions; this fixes those warnings.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
