### PR TITLE
Remove refence to incomplete Toga core tests

### DIFF
--- a/content/contributing/first-time/what/contents.lr
+++ b/content/contributing/first-time/what/contents.lr
@@ -89,10 +89,12 @@ of how this can be done, and the BeeWare team is happy to help if you
 need it. Jump on the [BeeWare Discord](/bee/chat/) and we'll do whatever
 we can to help!
 
-If you're not up for transforming code from one language to another -
-there's always the test suite. Toga's core library also has a test
-suite, but the coverage of that test suite isn't very good. Pick a
-widget interface, and see if you can write a test for it!
+Even if you're not up for transforming code from one language to another, Toga's core
+library — as well as Travertino, a subpackage covering styling and layout — are pure
+Python, and platform-agnostic. Take a look at [issues not tagged with a specific
+platform](https://github.com/search?q=repo%3Abeeware%2Ftoga+is%3Aissue+is%3Aopen+-label%3AmacOS+-label%3Alinux+-label%3Awindows+-label%3Aandroid+-label%3AiOS&type=issues)
+— many of them can probably be fixed with little or no change to any platform-specific
+code.
 
 ## Documentation
 


### PR DESCRIPTION
Toga's core test suite has enforced 100% coverage since 0.4.0, so this part is out of date. However, rather than remove it entirely, I thought it would be a good idea to suggest a different avenue for finding (potentially) Python-only issues.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
