### PR TITLE
Fix Dead Link in the First Ever Buzz Post

### DIFF
--- a/content/news/buzz/tips-core-contributor/contents.lr
+++ b/content/news/buzz/tips-core-contributor/contents.lr
@@ -8,7 +8,7 @@ At PyCon US 2016, Philip James became a Core Contributor to BeeWare!
 
 He wrote up some of his thoughts about the process in his article [Tips
 for Becoming a Core
-Contributor](https://web.archive.org/web/20190210101137/https://www.wordfugue.com/tips-becoming-core-contributor/).
+Contributor](https://phildini.dev/tips-becoming-core-contributor).
 
 Katie McLaughlin, who got her commit bit at DjangoCon Europe 2016,
 followed up with a post of her own, describing her path to [becoming a

--- a/content/news/buzz/tips-core-contributor/contents.lr
+++ b/content/news/buzz/tips-core-contributor/contents.lr
@@ -8,12 +8,12 @@ At PyCon US 2016, Philip James became a Core Contributor to BeeWare!
 
 He wrote up some of his thoughts about the process in his article [Tips
 for Becoming a Core
-Contributor](https://www.wordfugue.com/tips-becoming-core-contributor/).
+Contributor](https://web.archive.org/web/20190210101137/https://www.wordfugue.com/tips-becoming-core-contributor/).
 
 Katie McLaughlin, who got her commit bit at DjangoCon Europe 2016,
 followed up with a post of her own, describing her path to [becoming a
 core
-contributor](http://glasnt.com/blog/2016/06/08/on-becoming-a-core-contributor.html).
+contributor](https://glasnt.com/blog/on-becoming-a-core-contributor/).
 
 For those who aspire to become contributors to open source projects,
 it's helpful to hear how others got there.


### PR DESCRIPTION
First link is dead and the domain name seems to be some stuff that I'm not aware of, so replaced with Internet Archive.  Second link is by searching glasnt's blog's archives.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
