### PR TITLE
Fix PEP References

### DIFF
--- a/content/contributing/process/contents.lr
+++ b/content/contributing/process/contents.lr
@@ -127,7 +127,8 @@ Additional guidelines:
 - Use InitialCaps for class names (or for factory functions that return
   classes)
 
-- Use Sphinx-style docstrings and `257`; type annotation with `484` is
+- Use Sphinx-style docstrings and [PEP 257](https://peps.python.org/pep-0257/);
+  type annotation with [PEP 484](https://peps.python.org/pep-0484/) is
   optional but encouraged.
 
   For example:
@@ -153,8 +154,8 @@ Additional guidelines:
       def test_foo():
           """A test docstring looks like this (#123456)."""
 
-- Unless otherwise specified, follow `8` (with careful attention paid to
-  [Section
+- Unless otherwise specified, follow [PEP 8](https://peps.python.org/pep-0008/)
+  (with careful attention paid to [Section
   2](https://www.python.org/dev/peps/pep-0008/#a-foolish-consistency-is-the-hobgoblin-of-little-minds)).
 
 ---


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

We've marked down the importance of RST, but as a side effect, those links gets converted to code blocks and we lose some automation for PEP linking AFAIK.   I am not sure if there's a more automated way.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
