### PR TITLE
Member links from events pages, plus related and nearby tweaks that also distracted me

### DIFF
--- a/content/about/team/danyeaw/contents.lr
+++ b/content/about/team/danyeaw/contents.lr
@@ -27,5 +27,3 @@ emeritus_date:
 
 2021-05-01
 
----
-in_events: yes

--- a/content/about/team/danyeaw/contents.lr
+++ b/content/about/team/danyeaw/contents.lr
@@ -27,3 +27,5 @@ emeritus_date:
 
 2021-05-01
 
+---
+in_events: yes

--- a/content/about/team/freakboy3742/contents.lr
+++ b/content/about/team/freakboy3742/contents.lr
@@ -25,3 +25,5 @@ email: russell@beeware.org
 superpower: bdfn
 ---
 mastodon_handle: @freakboy3742@cloudisland.nz
+---
+in_events: yes

--- a/content/about/team/freakboy3742/contents.lr
+++ b/content/about/team/freakboy3742/contents.lr
@@ -25,5 +25,3 @@ email: russell@beeware.org
 superpower: bdfn
 ---
 mastodon_handle: @freakboy3742@cloudisland.nz
----
-in_events: yes

--- a/content/about/team/glasnt/contents.lr
+++ b/content/about/team/glasnt/contents.lr
@@ -24,5 +24,3 @@ email: katie@beeware.org
 superpower: batavia, lektor, senior
 ---
 summary: Tasmanian Devil Wrangler
----
-in_events: yes

--- a/content/about/team/glasnt/contents.lr
+++ b/content/about/team/glasnt/contents.lr
@@ -24,3 +24,5 @@ email: katie@beeware.org
 superpower: batavia, lektor, senior
 ---
 summary: Tasmanian Devil Wrangler
+---
+in_events: yes

--- a/content/about/team/hawkowl/contents.lr
+++ b/content/about/team/hawkowl/contents.lr
@@ -21,5 +21,3 @@ github_handle: hawkowl
 email: hawkowl@atleastfornow.net
 ---
 superpower: toga, lektor
----
-in_events: yes

--- a/content/about/team/hawkowl/contents.lr
+++ b/content/about/team/hawkowl/contents.lr
@@ -21,3 +21,5 @@ github_handle: hawkowl
 email: hawkowl@atleastfornow.net
 ---
 superpower: toga, lektor
+---
+in_events: yes

--- a/content/about/team/mhsmith/contents.lr
+++ b/content/about/team/mhsmith/contents.lr
@@ -20,5 +20,3 @@ github_handle: mhsmith
 email: smith@chaquo.com
 ---
 superpower: android
----
-in_events: yes

--- a/content/about/team/mhsmith/contents.lr
+++ b/content/about/team/mhsmith/contents.lr
@@ -20,3 +20,5 @@ github_handle: mhsmith
 email: smith@chaquo.com
 ---
 superpower: android
+---
+in_events: yes

--- a/content/about/team/phildini/contents.lr
+++ b/content/about/team/phildini/contents.lr
@@ -22,3 +22,5 @@ github_handle: phildini
 email: philip@beeware.org
 ---
 superpower: batavia, senior
+---
+in_events: yes

--- a/content/about/team/phildini/contents.lr
+++ b/content/about/team/phildini/contents.lr
@@ -22,5 +22,3 @@ github_handle: phildini
 email: philip@beeware.org
 ---
 superpower: batavia, senior
----
-in_events: yes

--- a/content/about/team/rmartin16/contents.lr
+++ b/content/about/team/rmartin16/contents.lr
@@ -17,5 +17,3 @@ github_handle: rmartin16
 email: rmartin16@gmail.com
 ---
 superpower: briefcase
----
-in_events: yes

--- a/content/about/team/rmartin16/contents.lr
+++ b/content/about/team/rmartin16/contents.lr
@@ -17,3 +17,5 @@ github_handle: rmartin16
 email: rmartin16@gmail.com
 ---
 superpower: briefcase
+---
+in_events: yes

--- a/content/about/team/swenson/contents.lr
+++ b/content/about/team/swenson/contents.lr
@@ -27,5 +27,3 @@ email: swenson@beeware.org
 superpower: batavia
 ---
 emeritus_date: 2021-05-01
----
-in_events: yes

--- a/content/about/team/swenson/contents.lr
+++ b/content/about/team/swenson/contents.lr
@@ -27,3 +27,5 @@ email: swenson@beeware.org
 superpower: batavia
 ---
 emeritus_date: 2021-05-01
+---
+in_events: yes

--- a/content/news/events/dev-world-2016/contents.lr
+++ b/content/news/events/dev-world-2016/contents.lr
@@ -4,7 +4,7 @@ date: 2016-08-29
 ---
 event_type: talk
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 talk_title: Apple and the Serpent: Writing native applications for Apple platforms in Python
 ---

--- a/content/news/events/django-under-the-hood-2016/contents.lr
+++ b/content/news/events/django-under-the-hood-2016/contents.lr
@@ -4,6 +4,6 @@ date: 2016-11-03
 ---
 event_type: attending
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 url: https://www.djangounderthehood.com/

--- a/content/news/events/djangocon-au-2017-rkm/contents.lr
+++ b/content/news/events/djangocon-au-2017-rkm/contents.lr
@@ -28,6 +28,6 @@ user model in practice.
 ---
 event_type: talk
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 talk_title: Red User, Blue User, MyUser, auth.User

--- a/content/news/events/djangocon-au-2017/contents.lr
+++ b/content/news/events/djangocon-au-2017/contents.lr
@@ -4,7 +4,7 @@ date: 2017-08-04
 ---
 event_type: attending
 ---
-speaker: Russell Keith-Magee, Katie McLaughlin, Amber Brown
+speaker: freakboy3742, glasnt, hawkowl
 ---
 description:
 

--- a/content/news/events/djangocon-europe-2017-sprints/contents.lr
+++ b/content/news/events/djangocon-europe-2017-sprints/contents.lr
@@ -4,6 +4,6 @@ date: 2017-04-06
 ---
 event_type: sprint
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 url: https://2017.djangocon.eu/

--- a/content/news/events/djangocon-europe-2017/contents.lr
+++ b/content/news/events/djangocon-europe-2017/contents.lr
@@ -28,7 +28,7 @@ mistakes if you're contemplating starting a business of your own?
 ---
 event_type: talk
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 talk_title: Autopsy of a slow train wreck: The life and death of a Django startup
 ---

--- a/content/news/events/djangocon-europe-2018-sprints/contents.lr
+++ b/content/news/events/djangocon-europe-2018-sprints/contents.lr
@@ -4,6 +4,6 @@ date: 2018-05-26
 ---
 event_type: sprint
 ---
-speaker: Russell Keith-Magee, Katie McLaughlin
+speaker: freakboy3742, glasnt
 ---
 url: https://2018.djangocon.eu/

--- a/content/news/events/djangocon-europe-2018/contents.lr
+++ b/content/news/events/djangocon-europe-2018/contents.lr
@@ -9,6 +9,6 @@ description:
 ---
 event_type: talk
 ---
-speaker: Russell Keith-Magee, Katie McLaughlin
+speaker: freakboy3742, glasnt
 ---
 url: https://2018.djangocon.eu/

--- a/content/news/events/djangocon-europe-2019-sprints/contents.lr
+++ b/content/news/events/djangocon-europe-2019-sprints/contents.lr
@@ -4,6 +4,6 @@ date: 2019-04-13
 ---
 event_type: sprint
 ---
-speaker: Russell Keith-Magee, Katie McLaughlin
+speaker: freakboy3742, glasnt
 ---
 url: https://2019.djangocon.eu/

--- a/content/news/events/djangocon-europe-2019/contents.lr
+++ b/content/news/events/djangocon-europe-2019/contents.lr
@@ -14,6 +14,6 @@ Django Community, not least those watching the talks online.
 ---
 event_type: attending
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 url: https://2019.djangocon.eu/

--- a/content/news/events/djangocon-us-2016-sprints/contents.lr
+++ b/content/news/events/djangocon-us-2016-sprints/contents.lr
@@ -4,6 +4,6 @@ date: 2016-07-21
 ---
 event_type: sprint
 ---
-speaker: Russell Keith-Magee, Philip James
+speaker: freakboy3742, phildini
 ---
 url: https://2016.djangocon.us/sprints/

--- a/content/news/events/djangocon-us-2016/contents.lr
+++ b/content/news/events/djangocon-us-2016/contents.lr
@@ -13,6 +13,6 @@ about BeeWare, they're keen to talk to anyone who wants to chat!
 ---
 event_type: attending
 ---
-speaker: Russell Keith-Magee, Philip James
+speaker: freakboy3742, phildini
 ---
 url: http://djangocon.us

--- a/content/news/events/djangocon-us-2017-km/contents.lr
+++ b/content/news/events/djangocon-us-2017-km/contents.lr
@@ -26,7 +26,7 @@ standard, and emoji accessibility in web applications. :sparkles:
 ---
 event_type: talk
 ---
-speaker: Katie McLaughlin
+speaker: glasnt
 ---
 talk_title: The Power ⚡️ and Responsibility 😅 of Unicode Adoption ✨
 ---

--- a/content/news/events/djangocon-us-2017-rkm/contents.lr
+++ b/content/news/events/djangocon-us-2017-rkm/contents.lr
@@ -28,7 +28,7 @@ mistakes if you’re contemplating starting a business of your own?
 ---
 event_type: talk
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 talk_title: Autopsy of a slow train wreck: The life and death of a Django startup
 ---

--- a/content/news/events/djangocon-us-2017-sprints/contents.lr
+++ b/content/news/events/djangocon-us-2017-sprints/contents.lr
@@ -4,6 +4,6 @@ date: 2017-08-17
 ---
 event_type: sprint
 ---
-speaker: Russell Keith-Magee, Philip James, Katie McLaughlin
+speaker: freakboy3742, phildini, glasnt
 ---
 url: https://2017.djangocon.us/sprints/

--- a/content/news/events/djangocon-us-2017/contents.lr
+++ b/content/news/events/djangocon-us-2017/contents.lr
@@ -18,6 +18,6 @@ with and discover new ways to use them, and have a lot of fun!
 ---
 event_type: attending
 ---
-speaker: Russell Keith-Magee, Philip James, Katie McLaughlin
+speaker: freakboy3742, phildini, glasnt
 ---
 url: https://2017.djangocon.us/

--- a/content/news/events/djangocon-us-2018-sprints/contents.lr
+++ b/content/news/events/djangocon-us-2018-sprints/contents.lr
@@ -4,6 +4,6 @@ date: 2018-10-17
 ---
 event_type: sprint
 ---
-speaker: Russell Keith-Magee, Philip James, Katie McLaughlin
+speaker: freakboy3742, phildini, glasnt
 ---
 url: https://2018.djangocon.us/

--- a/content/news/events/djangocon-us-2018/contents.lr
+++ b/content/news/events/djangocon-us-2018/contents.lr
@@ -23,7 +23,7 @@ This is going to take some… time.
 ---
 event_type: talk
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 url: https://2018.djangocon.us/
 ---

--- a/content/news/events/djangocon-us-2019-sprints/contents.lr
+++ b/content/news/events/djangocon-us-2019-sprints/contents.lr
@@ -4,6 +4,6 @@ date: 2019-09-26
 ---
 event_type: sprint
 ---
-speaker: Russell Keith-Magee, Philip James, Katie McLaughlin
+speaker: freakboy3742, phildini, glasnt
 ---
 url: https://2019.djangocon.us

--- a/content/news/events/djangocon-us-2019/contents.lr
+++ b/content/news/events/djangocon-us-2019/contents.lr
@@ -21,7 +21,7 @@ the web.
 ---
 event_type: talk
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 url: https://2017.djangocon.us/
 ---

--- a/content/news/events/djangocon-us-2022-sprints/contents.lr
+++ b/content/news/events/djangocon-us-2022-sprints/contents.lr
@@ -4,7 +4,7 @@ date: 2022-10-20
 ---
 event_type: sprint
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 url: https://2022.djangocon.us
 ---

--- a/content/news/events/djangocon-us-2022/contents.lr
+++ b/content/news/events/djangocon-us-2022/contents.lr
@@ -26,7 +26,7 @@ hit those limits.
 ---
 event_type: talk
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 url: https://2022.djangocon.us/
 ---

--- a/content/news/events/europython-2023-sprints/contents.lr
+++ b/content/news/events/europython-2023-sprints/contents.lr
@@ -4,6 +4,6 @@ date: 2023-07-22
 ---
 event_type: sprint
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 url: https://ep2023.europython.eu

--- a/content/news/events/europython-2023/contents.lr
+++ b/content/news/events/europython-2023/contents.lr
@@ -15,7 +15,7 @@ codebase.
 ---
 event_type: talk
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 talk_title: Packaging Python Apps with Briefcase
 ---

--- a/content/news/events/europython-2025-sprints/contents.lr
+++ b/content/news/events/europython-2025-sprints/contents.lr
@@ -4,7 +4,7 @@ date: 2025-07-19
 ---
 event_type: sprint
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 url: https://ep2025.europython.eu
 ---

--- a/content/news/events/europython-2025-tutorial/contents.lr
+++ b/content/news/events/europython-2025-tutorial/contents.lr
@@ -27,7 +27,7 @@ by you, using nothing but Python.
 ---
 event_type: tutorial
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 talk_title: Building a cross-platform app with BeeWare
 ---

--- a/content/news/events/europython-2025/contents.lr
+++ b/content/news/events/europython-2025/contents.lr
@@ -14,4 +14,4 @@ event_type: attending
 ---
 end_date: 2025-07-20
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742

--- a/content/news/events/everything-open-2023/contents.lr
+++ b/content/news/events/everything-open-2023/contents.lr
@@ -15,7 +15,7 @@ web - all from a single Python codebase.
 ---
 event_type: tutorial
 ---
-speaker: Russell Keith-Magee, Katie McLaughlin
+speaker: freakboy3742, glasnt
 ---
 talk_title: Building cross platform GUI apps with BeeWare
 ---

--- a/content/news/events/foss4g-2021/contents.lr
+++ b/content/news/events/foss4g-2021/contents.lr
@@ -13,7 +13,7 @@ obscure backwater - and the pitfalls to watch for along the way.
 ---
 event_type: keynote
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 talk_title: Open Source in the Antipodes
 ---

--- a/content/news/events/kiwi-pycon-xiii/contents.lr
+++ b/content/news/events/kiwi-pycon-xiii/contents.lr
@@ -17,7 +17,7 @@ may hold for Python.
 ---
 event_type: keynote
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 talk_title: Whither Python?
 ---

--- a/content/news/events/linuxconfau-2017-km/contents.lr
+++ b/content/news/events/linuxconfau-2017-km/contents.lr
@@ -2,7 +2,7 @@ title: Linux.conf.au 2017
 ---
 date: 2017-01-18
 ---
-speaker: Katie McLaughlin
+speaker: glasnt
 ---
 url: https://www.youtube.com/watch?v=k3brfCZSFiQ
 ---

--- a/content/news/events/linuxconfau-2017-rkm/contents.lr
+++ b/content/news/events/linuxconfau-2017-rkm/contents.lr
@@ -33,7 +33,7 @@ impose.
 ---
 event_type: talk
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 talk_title: Stranger in a strange land: Breaking language monocultures with open source
 ---

--- a/content/news/events/oscon-2017/contents.lr
+++ b/content/news/events/oscon-2017/contents.lr
@@ -4,7 +4,7 @@ date: 2017-05-11
 ---
 event_type: booth
 ---
-speaker: Katie McLaughlin
+speaker: glasnt
 ---
 url: 
 ---

--- a/content/news/events/pycaribbean-2017/contents.lr
+++ b/content/news/events/pycaribbean-2017/contents.lr
@@ -11,7 +11,7 @@ challenges face us as a community going into the future.
 ---
 event_type: keynote
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 talk_title: Why Python?
 ---

--- a/content/news/events/pycon-au-2016-sprints/contents.lr
+++ b/content/news/events/pycon-au-2016-sprints/contents.lr
@@ -6,4 +6,4 @@ event_type: sprint
 ---
 url:
 ---
-speaker: Russell Keith-Magee, Katie McLaughlin
+speaker: freakboy3742, glasnt

--- a/content/news/events/pycon-au-2016/contents.lr
+++ b/content/news/events/pycon-au-2016/contents.lr
@@ -31,7 +31,7 @@ addressing that lack of coverage.”
 ---
 event_type: keynote
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 talk_title: Keynote
 ---

--- a/content/news/events/pycon-au-2017-keynote/contents.lr
+++ b/content/news/events/pycon-au-2017-keynote/contents.lr
@@ -35,6 +35,6 @@ We are excited to hear Katie’s keynote address and contemplate
 ---
 event_type: keynote
 ---
-speaker: Katie McLaughlin
+speaker: glasnt
 ---
 talk_title: How to handle abandoned projects, Take Two

--- a/content/news/events/pycon-au-2017-rkm/contents.lr
+++ b/content/news/events/pycon-au-2017-rkm/contents.lr
@@ -19,7 +19,7 @@ codebase.
 ---
 event_type: talk
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 talk_title: Covered in Bees! Deploying an app to 6 platforms in 20 minutes
 ---

--- a/content/news/events/pycon-au-2017-sprints/contents.lr
+++ b/content/news/events/pycon-au-2017-sprints/contents.lr
@@ -4,4 +4,4 @@ date: 2017-8-7
 ---
 event_type: sprint
 ---
-speaker: Russell Keith-Magee, Katie McLaughlin, Amber Brown
+speaker: freakboy3742, glasnt, hawkowl

--- a/content/news/events/pycon-au-2017/contents.lr
+++ b/content/news/events/pycon-au-2017/contents.lr
@@ -25,6 +25,6 @@ PyCon Australia is held in two year blocks at the same city.
 ---
 event_type: attending
 ---
-speaker: Russell Keith-Magee, Katie McLaughlin, Amber Brown
+speaker: freakboy3742, glasnt, hawkowl
 ---
 talk_title: 

--- a/content/news/events/pycon-au-2018-sprints/contents.lr
+++ b/content/news/events/pycon-au-2018-sprints/contents.lr
@@ -4,6 +4,6 @@ date: 2018-08-27
 ---
 event_type: sprint
 ---
-speaker: Russell Keith-Magee, Katie McLaughlin
+speaker: freakboy3742, glasnt
 ---
 url: https://2018.pycon-au.org

--- a/content/news/events/pycon-au-2018/contents.lr
+++ b/content/news/events/pycon-au-2018/contents.lr
@@ -31,7 +31,7 @@ starting to emerge from the browser standardization process.
 ---
 event_type: talk
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 talk_title: A Web without JavaScript
 ---

--- a/content/news/events/pycon-au-2019-sprints/contents.lr
+++ b/content/news/events/pycon-au-2019-sprints/contents.lr
@@ -4,6 +4,6 @@ date: 2019-08-05
 ---
 event_type: sprint
 ---
-speaker: Russell Keith-Magee, Katie McLaughlin
+speaker: freakboy3742, glasnt
 ---
 url: https://2019.pycon-au.org

--- a/content/news/events/pycon-au-2019/contents.lr
+++ b/content/news/events/pycon-au-2019/contents.lr
@@ -21,7 +21,7 @@ the web.
 ---
 event_type: talk
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 talk_title: WASM matter?
 ---

--- a/content/news/events/pycon-au-2023-sprints/contents.lr
+++ b/content/news/events/pycon-au-2023-sprints/contents.lr
@@ -4,6 +4,6 @@ date: 2023-08-21
 ---
 event_type: sprint
 ---
-speaker: Russell Keith-Magee, Katie McLaughlin
+speaker: freakboy3742, glasnt
 ---
 url: https://2023.pycon.org.au

--- a/content/news/events/pycon-au-2023/contents.lr
+++ b/content/news/events/pycon-au-2023/contents.lr
@@ -16,7 +16,7 @@ macOS, Windows, Linux, iOS, Android, and the web.
 ---
 event_type: talk
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 talk_title: How to build a cross-platform graphical user interface with Python
 ---

--- a/content/news/events/pycon-au-2024-sprints/contents.lr
+++ b/content/news/events/pycon-au-2024-sprints/contents.lr
@@ -4,6 +4,6 @@ date: 2024-11-25
 ---
 event_type: sprint
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 url: https://2024.pycon.org.au/

--- a/content/news/events/pycon-au-2024/contents.lr
+++ b/content/news/events/pycon-au-2024/contents.lr
@@ -13,7 +13,7 @@ these sensors, using nothing but Python.
 ---
 event_type: talk
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 talk_title: Where am I? What am I doing? Mobile App development in Python
 ---

--- a/content/news/events/pycon-balkans-2018/contents.lr
+++ b/content/news/events/pycon-balkans-2018/contents.lr
@@ -9,7 +9,7 @@ description:
 ---
 event_type: keynote
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 talk_title: Tomorrow's Python
 ---

--- a/content/news/events/pycon-co-2019/contents.lr
+++ b/content/news/events/pycon-co-2019/contents.lr
@@ -9,7 +9,7 @@ description:
 ---
 event_type: keynote
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 talk_title: Future of Pythobn
 ---

--- a/content/news/events/pycon-th-2019/contents.lr
+++ b/content/news/events/pycon-th-2019/contents.lr
@@ -9,7 +9,7 @@ description:
 ---
 event_type: keynote
 ---
-speaker: Russell Keith-Magee, Katie McLaughlin, Amber Brown
+speaker: freakboy3742, glasnt, hawkowl
 ---
 talk_title: Python All The Things!
 ---

--- a/content/news/events/pycon-tw-2017/contents.lr
+++ b/content/news/events/pycon-tw-2017/contents.lr
@@ -4,7 +4,7 @@ date: 2017-06-09
 ---
 event_type: keynote
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 url: https://tw.pycon.org/2017/
 ---

--- a/content/news/events/pycon-us-2016-sprints/contents.lr
+++ b/content/news/events/pycon-us-2016-sprints/contents.lr
@@ -4,6 +4,6 @@ date: 2016-06-03
 ---
 event_type: sprint
 ---
-speaker: Philip James, Katie McLaughlin, Russell Keith-Magee
+speaker: phildini, glasnt, freakboy3742
 ---
 url: https://us.pycon.org/2016/

--- a/content/news/events/pycon-us-2016/contents.lr
+++ b/content/news/events/pycon-us-2016/contents.lr
@@ -4,7 +4,7 @@ date: 2016-06-01
 ---
 event_type: talk
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 talk_title: A Tale of Two Cellphones
 ---

--- a/content/news/events/pycon-us-2017-km/contents.lr
+++ b/content/news/events/pycon-us-2017-km/contents.lr
@@ -20,7 +20,7 @@ build an entire web platform in Python only.
 ---
 event_type: talk
 ---
-speaker: Katie McLaughlin
+speaker: glasnt
 ---
 talk_title: Snek in the browser
 ---

--- a/content/news/events/pycon-us-2017-rkm/contents.lr
+++ b/content/news/events/pycon-us-2017-rkm/contents.lr
@@ -19,7 +19,7 @@ code on the Java virtual machine.
 ---
 event_type: talk
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 talk_title: How to write a Python transpiler
 ---

--- a/content/news/events/pycon-us-2017-sprints/contents.lr
+++ b/content/news/events/pycon-us-2017-sprints/contents.lr
@@ -4,6 +4,6 @@ date: 2017-05-22
 ---
 event_type: sprint
 ---
-speaker: Christopher Swenson, Katie McLaughlin, Philip James, Russell Keith-Magee, Amber Brown
+speaker: swenson, glasnt, phildini, freakboy3742, hawkowl
 ---
 url: https://us.pycon.org/2017/

--- a/content/news/events/pycon-us-2017-tutorials/contents.lr
+++ b/content/news/events/pycon-us-2017-tutorials/contents.lr
@@ -21,7 +21,7 @@ to the application's codebase.
 ---
 event_type: tutorial
 ---
-speaker: Russell Keith-Magee, Katie McLaughlin
+speaker: freakboy3742, glasnt
 ---
 talk_title: Cross-platform Native GUI development with BeeWare
 ---

--- a/content/news/events/pycon-us-2017/contents.lr
+++ b/content/news/events/pycon-us-2017/contents.lr
@@ -4,7 +4,7 @@ date: 2017-05-19
 ---
 event_type: booth
 ---
-speaker: Russell Keith-Magee, Philip James, Katie McLaughlin, Christopher Swenson, Amber Brown
+speaker: freakboy3742, phildini, glasnt, swenson, hawkowl
 ---
 url: https://us.pycon.org/2017/
 ---

--- a/content/news/events/pycon-us-2018-booth/contents.lr
+++ b/content/news/events/pycon-us-2018-booth/contents.lr
@@ -4,7 +4,7 @@ date: 2018-05-11
 ---
 event_type: booth
 ---
-speaker: Katie McLaughlin, Philip James, Russell Keith-Magee
+speaker: glasnt, phildini, freakboy3742
 ---
 url: https://us.pycon.org/2018/
 ---

--- a/content/news/events/pycon-us-2018-sprints/contents.lr
+++ b/content/news/events/pycon-us-2018-sprints/contents.lr
@@ -4,6 +4,6 @@ date: 2018-05-14
 ---
 event_type: sprint
 ---
-speaker: Russell Keith-Magee, Philip James, Katie McLaughlin
+speaker: freakboy3742, phildini, glasnt
 ---
 url: https://us.pycon.org/2018/

--- a/content/news/events/pycon-us-2018/contents.lr
+++ b/content/news/events/pycon-us-2018/contents.lr
@@ -21,7 +21,7 @@ codebase.
 ---
 event_type: talk
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 talk_title: Building a cross-platform native app with BeeWare
 ---

--- a/content/news/events/pycon-us-2019-booth/contents.lr
+++ b/content/news/events/pycon-us-2019-booth/contents.lr
@@ -4,7 +4,7 @@ date: 2019-05-03
 ---
 event_type: booth
 ---
-speaker: Russell Keith-Magee, Katie McLaughlin, Philip James
+speaker: freakboy3742, glasnt, phildini
 ---
 url: https://us.pycon.org/2019/
 ---

--- a/content/news/events/pycon-us-2019-dy/contents.lr
+++ b/content/news/events/pycon-us-2019-dy/contents.lr
@@ -22,7 +22,7 @@ your own GUI widget in five easy steps.
 ---
 event_type: talk
 ---
-speaker: Dan Yeaw
+speaker: danyeaw
 ---
 talk_title: 5 Steps to Build Python Native GUI Widgets for BeeWare
 ---

--- a/content/news/events/pycon-us-2019-rkm/contents.lr
+++ b/content/news/events/pycon-us-2019-rkm/contents.lr
@@ -9,7 +9,7 @@ description:
 ---
 event_type: keynote
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 talk_title: Where do you see Python in 10 years?
 ---

--- a/content/news/events/pycon-us-2019-sprints/contents.lr
+++ b/content/news/events/pycon-us-2019-sprints/contents.lr
@@ -4,6 +4,6 @@ date: 2019-05-06
 ---
 event_type: sprint
 ---
-speaker: Russell Keith-Magee, Philip James, Katie McLaughlin, Dan Yeaw
+speaker: freakboy3742, phildini, glasnt, danyeaw
 ---
 url: https://us.pycon.org/2019/

--- a/content/news/events/pycon-us-2023-booth/contents.lr
+++ b/content/news/events/pycon-us-2023-booth/contents.lr
@@ -4,7 +4,7 @@ date: 2023-04-21
 ---
 event_type: booth
 ---
-speaker: Russell Keith-Magee, Malcolm Smith
+speaker: freakboy3742, mhsmith
 ---
 url: https://us.pycon.org/2024/
 ---

--- a/content/news/events/pycon-us-2023-ms/contents.lr
+++ b/content/news/events/pycon-us-2023-ms/contents.lr
@@ -21,7 +21,7 @@ In this talk, you'll learn about:
 ---
 event_type: talk
 ---
-speaker: Malcolm Smith
+speaker: mhsmith
 ---
 talk_title: Python on Android
 ---

--- a/content/news/events/pycon-us-2023-rkm/contents.lr
+++ b/content/news/events/pycon-us-2023-rkm/contents.lr
@@ -24,7 +24,7 @@ platforms from a single Python codebase.
 ---
 event_type: talk
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 talk_title: You *can* take it with you: Packaging your Python code with Briefcase
 ---

--- a/content/news/events/pycon-us-2023-sprints/contents.lr
+++ b/content/news/events/pycon-us-2023-sprints/contents.lr
@@ -4,6 +4,6 @@ date: 2023-04-24
 ---
 event_type: sprint
 ---
-speaker: Russell Keith-Magee, Malcolm Smith
+speaker: freakboy3742, mhsmith
 ---
 url: https://us.pycon.org/2023

--- a/content/news/events/pycon-us-2024-booth/contents.lr
+++ b/content/news/events/pycon-us-2024-booth/contents.lr
@@ -4,7 +4,7 @@ date: 2024-05-17
 ---
 event_type: booth
 ---
-speaker: Russell Keith-Magee, Russell Martin, Malcolm Smith
+speaker: freakboy3742, rmartin16, mhsmith
 ---
 url: https://us.pycon.org/2024/
 ---

--- a/content/news/events/pycon-us-2024-sprints/contents.lr
+++ b/content/news/events/pycon-us-2024-sprints/contents.lr
@@ -4,6 +4,6 @@ date: 2024-05-20
 ---
 event_type: sprint
 ---
-speaker: Russell Keith-Magee, Philip James, Malcolm Smith, Russell Martin
+speaker: freakboy3742, phildini, mhsmith, rmartin16
 ---
 url: https://us.pycon.org/2024/

--- a/content/news/events/pycon-us-2024-tutorial/contents.lr
+++ b/content/news/events/pycon-us-2024-tutorial/contents.lr
@@ -27,7 +27,7 @@ entirely by you, using nothing but Python.
 ---
 event_type: tutorial
 ---
-speaker: Russell Keith-Magee, Malcolm Smith, Russell Martin
+speaker: freakboy3742, mhsmith, rmartin16
 ---
 talk_title: Build a cross-platform app with BeeWare
 ---

--- a/content/news/events/pycon-us-2024/contents.lr
+++ b/content/news/events/pycon-us-2024/contents.lr
@@ -18,7 +18,7 @@ basic familiarity with Python.
 ---
 event_type: talk
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 talk_title: Build a data visualization app for your phone
 ---

--- a/content/news/events/pycon-us-2025-sprints/contents.lr
+++ b/content/news/events/pycon-us-2025-sprints/contents.lr
@@ -4,7 +4,7 @@ date: 2025-05-19
 ---
 event_type: sprint
 ---
-speaker: Russell Keith-Magee, Malcolm Smith
+speaker: freakboy3742, mhsmith
 ---
 url: https://us.pycon.org/2025/
 ---

--- a/content/news/events/pycon-us-2025-tutorial/contents.lr
+++ b/content/news/events/pycon-us-2025-tutorial/contents.lr
@@ -27,7 +27,7 @@ by you, using nothing but Python.
 ---
 event_type: tutorial
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 talk_title: Building a cross-platform app with BeeWare
 ---

--- a/content/news/events/pycon-us-2025/contents.lr
+++ b/content/news/events/pycon-us-2025/contents.lr
@@ -24,7 +24,7 @@ have a Python API.
 ---
 event_type: talk
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 talk_title: How to build a cross-platform graphical user interface with Python
 ---

--- a/content/news/events/pydx-2016/contents.lr
+++ b/content/news/events/pydx-2016/contents.lr
@@ -13,6 +13,6 @@ they're keen to talk to anyone who wants to chat!
 ---
 event_type: attending
 ---
-speaker: Philip James, Christopher Swenson
+speaker: phildini, swenson
 ---
 url: http://pydx.org/

--- a/content/news/events/pygotham-2016/contents.lr
+++ b/content/news/events/pygotham-2016/contents.lr
@@ -13,6 +13,6 @@ url: https://2016.pygotham.org/talks/240/a-tale-of-two-cellphones/
 ---
 event_type: talk
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 talk_title: A Tale Of Two Cellphones

--- a/content/news/events/pyohio-2016-sprints/contents.lr
+++ b/content/news/events/pyohio-2016-sprints/contents.lr
@@ -6,4 +6,4 @@ event_type: sprint
 ---
 url: https://pyohio.org/sprints/
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742

--- a/content/news/events/python-brasil-2016-sprints/contents.lr
+++ b/content/news/events/python-brasil-2016-sprints/contents.lr
@@ -4,6 +4,6 @@ date: 2016-10-18
 ---
 event_type: sprint
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 url: http://2016.pythonbrasil.org.br/

--- a/content/news/events/python-brasil-2016/contents.lr
+++ b/content/news/events/python-brasil-2016/contents.lr
@@ -4,7 +4,7 @@ date: 2016-10-15
 ---
 event_type: keynote
 ---
-speaker: Russell Keith-Magee
+speaker: freakboy3742
 ---
 talk_title: Python all the things!
 ---

--- a/content/news/events/wootconf-2017/contents.lr
+++ b/content/news/events/wootconf-2017/contents.lr
@@ -12,6 +12,6 @@ beyond.
 ---
 event_type: organizing
 ---
-speaker: Katie McLaughlin
+speaker: glasnt
 ---
 url: https://opensource.com/article/17/1/women-open-technology-miniconf

--- a/models/event.ini
+++ b/models/event.ini
@@ -19,7 +19,7 @@ width = 1/2
 [fields.speaker]
 label = Speakers
 type = checkboxes
-source = site.query('/about/team').filter(F.in_events == True)
+source = site.query("/about/team")
 width = 1/2
 
 [fields.url]

--- a/models/event.ini
+++ b/models/event.ini
@@ -19,8 +19,7 @@ width = 1/2
 [fields.speaker]
 label = Speakers
 type = checkboxes
-choices = Russell Keith-Magee, Philip James, Katie McLaughlin, Christopher Swenson, Amber Brown, Dan Yeaw, Malcolm Smith, Russell Martin
-choice_labels = Russell Keith-Magee, Philip James, Katie McLaughlin, Christopher Swenson, Amber Brown, Dan Yeaw, Malcolm Smith, Russell Martin
+source = site.query('/about/team').filter(F.in_events == True)
 width = 1/2
 
 [fields.url]

--- a/models/team-member.ini
+++ b/models/team-member.ini
@@ -1,6 +1,6 @@
 [model]
 name = Team Member
-label = {{ this.title }}
+label = {{ this.name }}
 hidden = no
 
 [fields.name]
@@ -46,12 +46,6 @@ width = 1/4
 label = Emeritus date
 width = 1/4
 type = date
-
-[fields.in_events]
-label = In Events
-width = 1/4
-type = boolean
-checkbox_label = Include as possibilities for event attendees
 
 [fields.description]
 label = Description

--- a/models/team-member.ini
+++ b/models/team-member.ini
@@ -47,6 +47,12 @@ label = Emeritus date
 width = 1/4
 type = date
 
+[fields.in_events]
+label = In Events
+width = 1/4
+type = boolean
+checkbox_label = Include as possibilities for event attendees
+
 [fields.description]
 label = Description
 description = Markdown

--- a/templates/event.html
+++ b/templates/event.html
@@ -51,7 +51,9 @@
 {% endblock %}
 
 {% block main %}
-{% if this.event_type == "sprint" %}
+{% if this.event_type in event_type_verbs %}
+  <p>{{ speakers }} {{ event_type_verbs[this.event_type]["before"] }} {{ this.title }} {{ event_type_verbs[this.event_type]["after"] }} "<a href="{{ this.url }}">{{ this.talk_title }}</a>".</p>
+{% elif this.event_type == "sprint" %}
   <p>{{ t_running_sprint }} {{ this.title }}.</p>
   <p>
     {{ speakers }} {% if this.speaker|length > 1 %}{{ t_sprint_helping_plural }}{% else %}{{ t_sprint_helping }}{% endif %} <a href="{{ '/contributing/challenge-coins/'|url(alt=this.alt) }}">{{ t_challenge_coin }}</a>.
@@ -59,8 +61,6 @@
   <p>{{ t_event_more_info }} <a href="{{ this.url }}">{{ this.title }} {{ t_website }}</a>.</p>
   <h3>{{ t_what_is_a_sprint }}</h3>
   <p>{{ t_sprint_description }} <a href="https://www.youtube.com/watch?v=hOtKgFaFcz0">{{ t_sprint_video }}</a> {{ t_post_sprint_pycon_video }} </p>
-{% else %}
-  <p>{{ speakers }} {{ event_type_verbs[this.event_type]["before"] }} {{ this.title }} {{ event_type_verbs[this.event_type]["after"] }} "<a href="{{ this.url }}">{{ this.talk_title }}</a>".</p>
 {% endif %}
 <p><em>{{ this.description }}</em></p>
 {% endblock %}

--- a/templates/event.html
+++ b/templates/event.html
@@ -1,6 +1,7 @@
 {% extends "page.html" %}
 {% from "macros/breadcrumbs.html" import breadcrumbs %}
 {% from "macros/translation.html" import transbag %}
+{% from "macros/join_and.html" import join_and %}
 
 {% set t_running_sprint = transbag('translate', this.alt, 'running_sprint') %}
 {% set t_what_is_a_sprint = transbag('translate', this.alt, 'what_is_a_sprint') %}
@@ -11,58 +12,79 @@
 {% set t_date = transbag('translate', this.alt, 'date') %}
 {% set t_speakers = transbag('translate', this.alt, 'speakers') %}
 {% set t_sprinters = transbag('translate', this.alt, 'sprinters') %}
-{% set t_and = " " + transbag('translate', this.alt, 'and')|trim + " " %}
+{% set t_and = transbag('translate', this.alt, 'and') %}
 {% set t_event_more_info = transbag('translate', this.alt, 'event_more_info') %}
 {% set t_website = transbag('translate', this.alt, 'website') %}
-{% set t_speaking_before_title = transbag('translate', this.alt, 'speaking_before_title') %}
-{% set t_speaking_after_title = transbag('translate', this.alt, 'speaking_after_title')|trim %}
-{% set t_keynoting_before_title = transbag('translate', this.alt, 'keynoting_before_title') %}
-{% set t_keynoting_after_title = transbag('translate', this.alt, 'keynoting_after_title')|trim %}
-{% set t_tutorial_before_title  = transbag('translate', this.alt, 'tutorial_before_title') %}
-{% set t_tutorial_after_title   = transbag('translate', this.alt, 'tutorial_after_title')|trim %}
+
 {% set t_sprint_helping = transbag('translate', this.alt, 'sprint_helping') %}
 {% set t_sprint_helping_plural = transbag('translate', this.alt, 'sprint_helping_plural') %}
 
+{%
+  set event_type_verbs = {
+    "talk": {
+        "before": transbag('translate', this.alt, 'speaking_before_title'),
+        "after": transbag('translate', this.alt, 'speaking_after_title'),
+    },
+    "keynote": {
+        "before": transbag('translate', this.alt, 'keynoting_before_title'),
+        "after": transbag('translate', this.alt, 'keynoting_after_title'),
+    },
+    "tutorial": {
+        "before": transbag('translate', this.alt, 'tutorial_before_title'),
+        "after": transbag('translate', this.alt, 'tutorial_after_title'),
+    },
+  }
+%}
+
+{% set speakers = join_and(this.speaker, t_and) %}
+
 {% block title %}{{ this.title }}{% endblock %}
+
 {% block preamble %}
 <div class="banner">
   <div class="container">
     <p>{{ breadcrumbs(this) }}</p>
     <h1>{{ this.title }} ({{ this.event_type|title }})</h1>
-    <p>{{ this.date|datetimeformat("EEEE, MMMM d, YYYY", locale=this.alt)|title }} {% if this.end_date %} - {{this.end_date|datetimeformat("EEEE, MMMM d, YYYY", locale=this.alt)|title}}{% endif %}</p>
+    <p>{{ this.date|datetimeformat("EEEE, MMMM d, YYYY", locale=this.alt)|title }}{% if this.end_date %} - {{this.end_date|datetimeformat("EEEE, MMMM d, YYYY", locale=this.alt)|title}}{% endif %}</p>
   </div>
 </div>
 {% endblock %}
+
 {% block main %}
-{% if this.event_type == "talk" %}
-    <p>{{ this.speaker|join(t_and)}} {{ t_speaking_before_title }} {{ this.title }} {{ t_speaking_after_title }} "<a href="{{ this.url }}">{{ this.talk_title }}</a>".
-{% elif this.event_type == "keynote" %}
-    <p>{{ this.speaker|join(t_and)}} {{ t_keynoting_before_title }} {{ this.title }} {{ t_keynoting_after_title }} "<a href="{{ this.url }}">{{ this.talk_title }}</a>".
-{% elif this.event_type == "tutorial" %}
-    <p>{{ this.speaker|join(t_and)}} {{ t_tutorial_before_title }} {{ this.title }} {{ t_tutorial_after_title }} "<a href="{{ this.url }}">{{ this.talk_title }}</a>".
-{% elif this.event_type == "sprint" %}
-    <p>{{ t_running_sprint }} {{ this.title }}.</p>
-  <p>{{ this.speaker|join(t_and) }} {% if this.speaker|length > 1 %}{{ t_sprint_helping_plural }}{% else %}{{ t_sprint_helping }}{% endif %} <a href="{{ '/contributing/challenge-coins/'|url(alt=this.alt) }}">{{ t_challenge_coin }}</a>.
-  <p>{{ t_event_more_info }}<a href="{{ this.url }}">{{ this.title }} {{ t_website }}</a></p>
+{% if this.event_type == "sprint" %}
+  <p>{{ t_running_sprint }} {{ this.title }}.</p>
+  <p>
+    {{ speakers }} {% if this.speaker|length > 1 %}{{ t_sprint_helping_plural }}{% else %}{{ t_sprint_helping }}{% endif %} <a href="{{ '/contributing/challenge-coins/'|url(alt=this.alt) }}">{{ t_challenge_coin }}</a>.
+  </p>
+  <p>{{ t_event_more_info }} <a href="{{ this.url }}">{{ this.title }} {{ t_website }}</a>.</p>
   <h3>{{ t_what_is_a_sprint }}</h3>
   <p>{{ t_sprint_description }} <a href="https://www.youtube.com/watch?v=hOtKgFaFcz0">{{ t_sprint_video }}</a> {{ t_post_sprint_pycon_video }} </p>
+{% else %}
+  <p>{{ speakers }} {{ event_type_verbs[this.event_type]["before"] }} {{ this.title }} {{ event_type_verbs[this.event_type]["after"] }} "<a href="{{ this.url }}">{{ this.talk_title }}</a>".</p>
 {% endif %}
 <p><em>{{ this.description }}</em></p>
 {% endblock %}
+
 {% block gutter %}
   <div class="col-sm-12 col-md-4 gutter">
     <dl>
-      <dt>{{ t_date|trim }}:</dt>
+      <dt>{{ t_date }}:</dt>
       <dd>{{ this.date|datetimeformat("MMMM d, YYYY", locale=this.alt)|title }}{% if this.end_date %} - {{this.end_date|datetimeformat("MMMM d, YYYY", locale=this.alt)|title}}{% endif %}</dd>
 
       {% if this.event_type == "sprint" %}
-        <dt>{{ t_sprinters|trim }}:</dt>
+        <dt>{{ t_sprinters }}:</dt>
       {% elif this.event_type == "talk" %}
-        <dt>{{ t_speakers|trim }}:</dt>
+        <dt>{{ t_speakers }}:</dt>
       {% endif %}
       <dd>
         <ul>
-        {% for name in this.speaker %}<li>{{ name }}</li>{% endfor %}
+        {% for name in this.speaker %}
+          <li><a href="{{
+              "/about/team"|url
+              + "#"
+              + site.query("/about/team").filter(F.name == name).first()._slug
+        }}">{{ name }}</a></li>
+        {% endfor %}
         </ul>
       </dd>
 

--- a/templates/event.html
+++ b/templates/event.html
@@ -36,7 +36,18 @@
   }
 %}
 
-{% set speakers = join_and(this.speaker, t_and) %}
+{% set member_slugs = this.speaker %}
+{% set members = site.query("/about/team") %}
+{% set speaker_names = {} %}
+
+{% for slug in this.speaker %}
+    {%
+        do speaker_names.update(
+            {slug: members.filter(F._slug == slug).first().name}
+        )
+    %}
+{% endfor %}
+{% set t_speakers_list = join_and(speaker_names.values()|list, t_and) %}
 
 {% block title %}{{ this.title }}{% endblock %}
 
@@ -52,11 +63,11 @@
 
 {% block main %}
 {% if this.event_type in event_type_verbs %}
-  <p>{{ speakers }} {{ event_type_verbs[this.event_type]["before"] }} {{ this.title }} {{ event_type_verbs[this.event_type]["after"] }} "<a href="{{ this.url }}">{{ this.talk_title }}</a>".</p>
+  <p>{{ t_speakers_list }} {{ event_type_verbs[this.event_type]["before"] }} {{ this.title }} {{ event_type_verbs[this.event_type]["after"] }} "<a href="{{ this.url }}">{{ this.talk_title }}</a>".</p>
 {% elif this.event_type == "sprint" %}
   <p>{{ t_running_sprint }} {{ this.title }}.</p>
   <p>
-    {{ speakers }} {% if this.speaker|length > 1 %}{{ t_sprint_helping_plural }}{% else %}{{ t_sprint_helping }}{% endif %} <a href="{{ '/contributing/challenge-coins/'|url(alt=this.alt) }}">{{ t_challenge_coin }}</a>.
+    {{ t_speakers_list }} {% if this.speaker|length > 1 %}{{ t_sprint_helping_plural }}{% else %}{{ t_sprint_helping }}{% endif %} <a href="{{ '/contributing/challenge-coins/'|url(alt=this.alt) }}">{{ t_challenge_coin }}</a>.
   </p>
   <p>{{ t_event_more_info }} <a href="{{ this.url }}">{{ this.title }} {{ t_website }}</a>.</p>
   <h3>{{ t_what_is_a_sprint }}</h3>
@@ -78,12 +89,12 @@
       {% endif %}
       <dd>
         <ul>
-        {% for name in this.speaker %}
+        {% for slug in speaker_names %}
           <li><a href="{{
               "/about/team"|url
               + "#"
-              + site.query("/about/team").filter(F.name == name).first()._slug
-        }}">{{ name }}</a></li>
+              + slug
+        }}">{{ speaker_names[slug] }}</a></li>
         {% endfor %}
         </ul>
       </dd>

--- a/templates/macros/join_and.html
+++ b/templates/macros/join_and.html
@@ -5,7 +5,7 @@
 }}{% 
     elif items|length == 2
 %}{{
-    " {} ".format(join_word).format(items)
+    " {} ".format(join_word).join(items)
 }}{%
     else
 %}{{ 

--- a/templates/macros/join_and.html
+++ b/templates/macros/join_and.html
@@ -1,0 +1,18 @@
+{% macro join_and(items, join_word="and") %}{% 
+    if items|length == 1 
+%}{{ 
+    items[0]
+}}{% 
+    elif items|length == 2
+%}{{
+    " {} ".format(join_word).format(items)
+}}{%
+    else
+%}{{ 
+    ", ".join(
+        items[:-2]
+        + [", {} ".format(join_word).join(items[-2:])]
+    )
+}}{% 
+    endif 
+%}{% endmacro %}

--- a/templates/macros/translation.html
+++ b/templates/macros/translation.html
@@ -1,3 +1,5 @@
-{% macro transbag(bag_name, alt, key, alt_default='en') %}
-{{ bag(bag_name, alt, key)|default(bag(bag_name, alt_default, key), true)|default("", true)}}
-{% endmacro %}
+{% macro transbag(bag_name, alt, key, alt_default='en') %}{{ 
+    bag(bag_name, alt, key)
+    |default(bag(bag_name, alt_default, key), true)
+    |default("", true)
+}}{% endmacro %}

--- a/templates/team.html
+++ b/templates/team.html
@@ -7,24 +7,24 @@
 {{ this.body }}
   </div>
 </div>
-<h2>Current team</h2>
+<h2 id="current-team">Current team</h2>
 {% for child in this.children.filter(F.emeritus_date == null) %}
 <div class="row team">
   <div class="col-xs-12 col-sm-7 col-md-7 col-lg-8 col-xl-9">
-    <h3>{{ child.name }}</h3>
-    <p>{{ child.description }}</p>
+    <h3 id="{{ child._slug }}">{{ child.name }}</h3>
+    {{ child.description }}
   </div>
   <div class="col-xs-12 col-sm-5 col-md-5 col-lg-4 col-xl-3 gutter">
     {{ member_badge(child) }}
   </div>
 </div>
 {% endfor %}
-<h2>Emeritus team members</h2>
+<h2 id="emeritus-team">Emeritus team members</h2>
 {% for child in this.children.filter(F.emeritus_date != null).order_by('emeritus_date') %}
 <div class="row team">
   <div class="col-xs-12 col-sm-7 col-md-7 col-lg-8 col-xl-9">
-    <h3>{{ child.name }}</h3>
-    <p>{{ child.description }}</p>
+    <h3 id="{{ child._slug }}">{{ child.name }}</h3>
+    {{ child.description }}
   </div>
   <div class="col-xs-12 col-sm-5 col-md-5 col-lg-4 col-xl-3 gutter">
     {{ member_badge(child) }}

--- a/templates/team.html
+++ b/templates/team.html
@@ -20,7 +20,7 @@
 </div>
 {% endfor %}
 <h2 id="emeritus-team">Emeritus team members</h2>
-{% for child in this.children.filter(F.emeritus_date != null).order_by('emeritus_date') %}
+{% for child in this.children.filter(F.emeritus_date).order_by('emeritus_date') %}
 <div class="row team">
   <div class="col-xs-12 col-sm-7 col-md-7 col-lg-8 col-xl-9">
     <h3 id="{{ child._slug }}">{{ child.name }}</h3>


### PR DESCRIPTION
- Team members now each have their own anchor.
- The sidebar list of people attending an event now links to those anchors.
- The list of available people to select when creating/editing events is now pulled dynamically from all team members, as long as they have the newly added "In events" boolean field checked.
- Groups of three or more speakers now join properly with commas. (I don't know if this is correct for all languages, but it is at least using the translated "and" in each case.)
- Simplified(?) some logic on the event pages.
- Fixed an issue with errant line breaks getting introduced in the `transbag` macro. *Excess* whitespace makes no difference in rendering of HTML if there was supposed to be some there anyway, but it can be an issue between pieces of text that should be continuous (such as "Challenge Coin ."[sic]). Jinja being a templating language means any whitespace outside of its own tags will be faithfully reproduced, which isn't always intuitive.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
