### PR TITLE
Ignore vendored code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,8 @@
+# Display proper Jinja syntax highlighting
+
 *.html linguist-language=Jinja
+
+# Exclude vendored code from our language stats
+
+assets/static/bootstrap linguist-vendored
+assets/static/tether-* linguist-vendored


### PR DESCRIPTION
In addition to fixing syntax highlighting in #658, we can also tell Github to ignore vendored code when tallying up which languages we're using. So, it should get rid of basically all of this JavaScript:

![Screenshot of current language display](https://github.com/user-attachments/assets/a3b5c601-2493-4db5-abf5-630dfc6777f5)

https://github.com/github-linguist/linguist/blob/main/docs/overrides.md


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
