### PR TITLE
Fix globs in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,5 +4,5 @@
 
 # Exclude vendored code from our language stats
 
-assets/static/bootstrap linguist-vendored
-assets/static/tether-* linguist-vendored
+assets/static/bootstrap/** linguist-vendored
+assets/static/tether-*/** linguist-vendored


### PR DESCRIPTION
Guess this is what I get for jumping the gun and committing my own PR... I messed up the globs in #659, which is why our language display still hasn't updated even after waiting a while. I *think* this should be correct, based on the examples at https://github.com/github-linguist/linguist/blob/main/docs/overrides.md.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
