### PR TITLE
Don't Translate Event Names

### DIFF
--- a/models/event.ini
+++ b/models/event.ini
@@ -7,7 +7,6 @@ hidden = no
 label = Title
 type = string
 size = large
-translate = True
 
 [fields.event_type]
 label = Event Type


### PR DESCRIPTION
Don't put event names in the po file when we're going to a conference.  Devs usually use english conference names when talking about things.  For example, https://tw.pycon.org/2025/zh-hant mentions the conference as PyCon Taiwan even in the Chinese Traditional text (which I can read a bit of).

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
