### PR TITLE
Add link to good first issue query on GH to sprinting guide

### DIFF
--- a/content/contributing/sprint-guide/contents.lr
+++ b/content/contributing/sprint-guide/contents.lr
@@ -117,8 +117,8 @@ a area where you should be able to make a contribution.
 If you've spoken to a member of the Bee Team, they have probably pointed
 you at a part of the BeeWare project where you can contribute; they
 might have even suggested a specific issue to work on. If they haven't
-given you as specific issue, they've probably pointed you at the "Good
-First Issues" for that project. What does that mean?
+given you as specific issue, they've probably pointed you at the "[Good
+First Issues](https://github.com/search?q=user%3Abeeware+label%3A%22good%20first%20issue%22+is%3Aissue+is%3Aopen&type=issues)" for that project. What does that mean?
 
 GitHub provides a list of issues that allows BeeWare (and other
 projects) to keep track of all the problems that have been reported -
@@ -131,7 +131,7 @@ suited to a first time contributor - issues that don't demand an
 have a good lead on the underlying cause. These issues are tagged "good
 first issue" to make them easier to find.
 
-To filter a GitHub issue list by the "good first issue" label, follow
+To filter a GitHub issue list by the "[good first issue](https://github.com/search?q=user%3Abeeware+label%3A%22good%20first%20issue%22+is%3Aissue+is%3Aopen&type=issues)" label, follow
 these steps:
 
 1.  Click on the "Labels" button above the list of issues to activate


### PR DESCRIPTION
Link to the "[good first issue](https://github.com/search?q=user%3Abeeware+label%3A%22good%20first%20issue%22+is%3Aissue+is%3Aopen&type=issues)" query to the sprinting page to match the contributing guide.

Nice to have for first timers in addition to instructions on how to use GH to query for good first issues manually.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x ] All new features have been tested
- [ ] All new features have been documented
- [ x ] I have read the **CONTRIBUTING.md** file
- [ x ] I will abide by the code of conduct
