### PR TITLE
Replace references to black, pyupgrade, isort, flake8 docs with Ruff

### DIFF
--- a/content/contributing/process/contents.lr
+++ b/content/contributing/process/contents.lr
@@ -103,16 +103,9 @@ with each `git` commit, run `pre-commit install`.
 
 Included Pre-commit checks:
 
-- [Black](https://black.readthedocs.io/en/stable/index.html) ensures
-  uniform code formatting
+- [Ruff](https://docs.astral.sh/ruff/) linting and code formatting
 - [docformatter](https://docformatter.readthedocs.io/en/latest/) ensures
   uniform formatting for docstrings and comments
-- [pyupgrade](https://github.com/asottile/pyupgrade) ensures code is
-  using the latest best practices for Python
-- [isort](https://pycqa.github.io/isort/) ensures uniform `import`
-  statements
-- [flake8](https://flake8.pycqa.org/en/latest/) checks for common coding
-  and syntax issues
 - Misc checks that validate structured documents such as TOML files and
   remove unnecessary whitespace
 


### PR DESCRIPTION
Remove references to black, pyupgrade, isort, and flake8 in contributing/process.

Replaces out of date references with current implementation for linting and code formatting.

<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->
Fixes [#623 ](https://github.com/beeware/beeware.github.io/issues/623)

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [ x ] I have read the **CONTRIBUTING.md** file
- [ x ] I will abide by the code of conduct
