### PR TITLE
Correct a typo in GitHub workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Lock Weblate and Sync
       run: wlc lock
     - name: Commit Weblate changes
-      run: wlc lock
+      run: wlc commit
     - name: Push Weblate changes
       run: wlc push
     - name: Pull translation updates pushed by Weblate


### PR DESCRIPTION
commit before pushing Weblate changes; hasn't been causing trouble because it seems to be done implicitly, however we don't want any sort of potential future weird configuration at Weblate to mess this up, and like the Zen of Python says, "Explicit is better than Implicit".

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
