### PR TITLE
Correct changelog link

### DIFF
--- a/content/community/behavior/changes/contents.lr
+++ b/content/community/behavior/changes/contents.lr
@@ -20,7 +20,7 @@ gutter:
 
 Only major substantive changes are listed here; For a complete list of
 all changes, see [the changelog of the GitHub
-repository](https://github.com/beeware/beeware.github.io/commits/master/content/community/behavior).
+repository](https://github.com/beeware/beeware.github.io/commits/lektor/content/community/behavior).
 
 ---
 sort_key: 3


### PR DESCRIPTION
I am unfamiliar with the history of the various branches on this project, however, it looks like at one point the master branch was abandoned in favor of developing on the lektor branch.  Update a changelog link to the GitHub interface to reflect that.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
