### PR TITLE
Exclude web from "issues not tagged with a specific platform"

### DIFF
--- a/content/contributing/first-time/what/contents.lr
+++ b/content/contributing/first-time/what/contents.lr
@@ -92,7 +92,7 @@ we can to help!
 Even if you're not up for transforming code from one language to another, Toga's core
 library — as well as Travertino, a subpackage covering styling and layout — are pure
 Python, and platform-agnostic. Take a look at [issues not tagged with a specific
-platform](https://github.com/search?q=repo%3Abeeware%2Ftoga+is%3Aissue+is%3Aopen+-label%3AmacOS+-label%3Alinux+-label%3Awindows+-label%3Aandroid+-label%3AiOS&type=issues)
+platform](https://github.com/search?q=repo%3Abeeware%2Ftoga+is%3Aissue+is%3Aopen+-label%3AmacOS+-label%3Alinux+-label%3Awindows+-label%3Aandroid+-label%3AiOS+-label%3Aweb&type=issues)
 — many of them can probably be fixed with little or no change to any platform-specific
 code.
 


### PR DESCRIPTION
There's a link "issues not tagged with a specific platform" in the "What to Do" section of the contribution docs that links to a GitHub page excluding all platform filters; however, that filter misses the Web backend, which we as a project treat as a platform.  There is no textual tag AFAIK so I'm not including that.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
