### PR TITLE
Update project links to point at current docs locations

### DIFF
--- a/content/bee/podium/contents.lr
+++ b/content/bee/podium/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-new_path: /docs/applications/podium/
+new_path: https://github.com/beeware/podium
 ---
 _discoverable: no

--- a/content/briefcase/contents.lr
+++ b/content/briefcase/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-new_path: /docs/briefcase/
+new_path: https://briefcase.beeware.org/
 ---
 _discoverable: no

--- a/content/docs/attic/python-android-template/contents.lr
+++ b/content/docs/attic/python-android-template/contents.lr
@@ -21,7 +21,7 @@ such as phones and tablets. It uses
 [cookiecutter](https://cookiecutter.readthedocs.io) which creates
 projects from cookiecutters (project templates). The easiest way to use
 this project is to not use it at all - at least, not directly.
-[Briefcase](/docs/briefcase) is a tool that uses this template,
+[Briefcase](https://briefcase.beeware.org/) is a tool that uses this template,
 rolling it out using data extracted from your setup.py
 
 The following Python versions are supported:

--- a/content/docs/attic/python-ios-support/contents.lr
+++ b/content/docs/attic/python-ios-support/contents.lr
@@ -20,7 +20,7 @@ A meta-package for building a version of Python that can be embedded
 into an iOS project.
 
 This project has been superceded by [Python Apple
-support](/docs/utilities/python-apple-support) package.
+support](https://github.com/beeware/Python-Apple-support) package.
 
 ---
 help_required:

--- a/content/docs/attic/python-osx-support/contents.lr
+++ b/content/docs/attic/python-osx-support/contents.lr
@@ -20,7 +20,7 @@ A meta-package for building a version of Python that can be embedded
 into a macOS (neé OS X) project.
 
 This project has been superceded by [Python Apple
-support](/docs/utilities/python-apple-support) package.
+support](https://github.com/beeware/Python-Apple-support) package.
 
 ---
 help_required:

--- a/content/docs/attic/python-tvos-support/contents.lr
+++ b/content/docs/attic/python-tvos-support/contents.lr
@@ -20,7 +20,7 @@ A meta-package for building a version of Python that can be embedded
 into a tvOS project.
 
 This project has been superceded by [Python Apple
-support](/docs/utilities/python-apple-support) package.
+support](https://github.com/beeware/Python-Apple-support) package.
 
 ---
 help_required:

--- a/content/docs/briefcase/contents.lr
+++ b/content/docs/briefcase/contents.lr
@@ -31,7 +31,7 @@ native application. You can package projects for:
 Support for Apple TV, watchOS, and Wear OS is planned.
 
 If you want to see Briefcase in action, try the [BeeWare
-tutorial](https://beeware.readthedocs.io). That tutorial walks you
+tutorial](https://tutorial.beeware.org). That tutorial walks you
 through the process of creating and packaging a new application with
 Briefcase.
 
@@ -57,7 +57,7 @@ image: briefcase.png
 ---
 github_repo: beeware/briefcase
 ---
-_slug: 
+_slug:
 ---
 sort_key: 2
 ---

--- a/content/docs/utilities/colosseum/contents.lr
+++ b/content/docs/utilities/colosseum/contents.lr
@@ -22,7 +22,7 @@ laid out on a page (either physical or virtual).
 
 It takes a tree of content "nodes", such as a DOM from a HTML document,
 and applies CSS styling instructions to layout those nodes as boxes on
-the screen. In the case of [Toga](/docs/toga/), instead of laying out
+the screen. In the case of [Toga](https://toga.beeware.org/), instead of laying out
 &lt;div&gt; and &lt;span&gt; elements, you lay out Box and Button
 objects. This allows you to specify incredibly complex, adaptive layouts
 for Toga applications.

--- a/content/docs/utilities/travertino/contents.lr
+++ b/content/docs/utilities/travertino/contents.lr
@@ -19,7 +19,7 @@ Travertino is a library describing constants and a base box model that
 can be used to define layout algorithms.
 
 It is used as a foundation for the Pack box model in
-[Toga](/docs/toga), and for
+[Toga](https://toga.beeware.org/), and for
 [Colosseum](/docs/utilities/colosseum/).
 
 ---

--- a/content/project/applications/podium/contents.lr
+++ b/content/project/applications/podium/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-new_path: /docs/applications/podium/
+new_path: https://github.com/beeware/podium
 ---
 _discoverable: no

--- a/content/project/projects/applications/podium/contents.lr
+++ b/content/project/projects/applications/podium/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-new_path: /docs/applications/podium/
+new_path: https://github.com/beeware/podium
 ---
 _discoverable: no

--- a/content/project/projects/support/python-apple-support/contents.lr
+++ b/content/project/projects/support/python-apple-support/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-new_path: /docs/utilities/python-apple-support/
+new_path: https://github.com/beeware/Python-Apple-support
 ---
 _discoverable: no

--- a/content/project/utilities/python-apple-support/contents.lr
+++ b/content/project/utilities/python-apple-support/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-new_path: /docs/utilities/python-apple-support/
+new_path: https://github.com/beeware/Python-Apple-support
 ---
 _discoverable: no

--- a/content/toga/contents.lr
+++ b/content/toga/contents.lr
@@ -1,5 +1,5 @@
 _model: redirect
 ---
-new_path: /docs/toga/
+new_path: https://toga.beeware.org/
 ---
 _discoverable: no

--- a/templates/home_sidebar.html
+++ b/templates/home_sidebar.html
@@ -34,7 +34,7 @@
     {% for project in project_types %}
         {% if not project.project_page_description %}
     <div>
-      <h4><a href="{{ project|url(alt=this.alt) }}"><img src="{{ site.get(project.path, alt='_primary')|url }}{{ project.image }}" height="32px" alt="{{ project.name }}"> {{ project.name }}</h4></a>
+      <h4><a href="https://{{ project.rtfd_name }}.beeware.org/"><img src="{{ site.get(project.path, alt='_primary')|url }}{{ project.image }}" height="32px" alt="{{ project.name }}"> {{ project.name }}</h4></a>
       {{ project.short_description|safe }}
     </div>
         {% endif %}


### PR DESCRIPTION
In the recent documentation reorg, we missed a couple of places where the old documentation project pages were referenced in surfaced content:

* The project links on the homepage right sidebar pointed at `/docs/toga` and `/docs/briefcase`
* Redirects for `/briefcase` and `/project/briefcase` pointed to `/docs/briefcase` (similar for toga, podium, and Python-Apple-support)
* Old references to pages under the `project` tree were updated to point at a `docs` equivalent
* The `/docs/briefcase` project page contained a reference to `beeware.readthedocs.io` as the tutorial

The last one was reported as #718.

Ultimately, in the current content layout, the old "project" pages (like `/docs/briefcase`) should no longer exist. However, we can't completely remove them because so much of the page layout depends on having a database of "projects" to iterate over. This set of changes retains the project pages, but removes any links to them so they are at least hard to find; and if they are found, they'll point at correct content.

/me puts another notch in the "we need to get rid of lector" post...

Fixes #718 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
