### PR TITLE
fix broken links in challenge coins page

### DIFF
--- a/content/contributing/challenge-coins/contents.lr
+++ b/content/contributing/challenge-coins/contents.lr
@@ -44,16 +44,15 @@ Coin.</em></figcaption>
 </figure>
 
 The first run of 100 BeeWare Challenge Coins were commissioned thanks to
-financial support from [MaxCDN](/community/members/maxcdn/). They also
-wrote an [article about
+financial support from MaxCDN. They also wrote an [article about
 BeeWare](https://web.archive.org/web/20170923205703/https://www.maxcdn.com/blog/beeware-be-sticky/)
 on their blog.
 
-[Revolution Systems](/community/members/revsys/) provided the funding
-for the second pressing of the BeeWare challenge coins.
+Revolution Systems provided the funding for the second pressing of the
+BeeWare challenge coins.
 
-[GitHub](/community/members/github/) provided the funding for the first
-pressing of the BeeWare Yak Herder challenge coins.
+GitHub provided the funding for the first pressing of the BeeWare Yak
+Herder challenge coins.
 
 <figure>
 <img src="/contributing/challenge-coins/sprint-coin.jpg"


### PR DESCRIPTION
## Description

Fixed broken links on the challenge coins page. Three sponsor links were pointing to deleted member pages (`/community/members/maxcdn/`, `/community/members/revsys/`, and `/community/members/github/`) that were removed when Anaconda was added.

The links have been removed while keeping the company names as plain text to still acknowledge their historical contributions.

## PR Checklist:

- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
