### PR TITLE
Revert "Bump flask from 2.3.3 to 3.1.3"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Lektor==3.3.12
 # These are pinned because they're versions that are known to work
 Babel==2.17.0
 EXIFRead==3.0.0
-Flask==3.1.3
+Flask==2.3.3
 Jinja2==3.1.6
 Lektor==3.3.12
 Werkzeug==2.3.8


### PR DESCRIPTION
Reverts beeware/beeware.github.io#744

Although there's a Dependabot security issue tied to this, we're not exposed; and we can't update Flask without also updating Werkzeug (amongst other packages). The [publication CI pass tied to this PR failed](https://github.com/beeware/beeware.github.io/actions/runs/22245585788) because of that dependency. 

/cc @kattni for visibility