### PR TITLE
Bump rumdl-pre-commit from v0.1.11 to v0.1.33

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,6 @@ repos:
         exclude: "locales"
       - id: trailing-whitespace
   - repo: https://github.com/rvben/rumdl-pre-commit
-    rev: v0.1.11
+    rev: v0.1.33
     hooks:
       - id: rumdl


### PR DESCRIPTION
Bumps `pre-commit` hook for `rumdl-pre-commit` from v0.1.11 to v0.1.33 and ran the update against the repo.