### PR TITLE
Remove the redirect for mobile-wheels.

### DIFF
--- a/docs/config.yml
+++ b/docs/config.yml
@@ -281,5 +281,3 @@ plugins:
       "bee/sprints.md": "contributing/sprint-guide.md"
       # Historical links of significance
       "community/behavior/code-of-conduct.md": "community/code-of-conduct.md"
-      # Temporary redirect for mobile-wheels until we're back on GH pages hosting
-      "mobile-wheels.md": "https://beeware.github.io/mobile-wheels/"


### PR DESCRIPTION
We had a temporary redirect in place while we were using RTD for hosting. As we're moving back to GitHub Pages, we can  remove that redirect.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
