### PR TITLE
Bump rumdl-pre-commit from v0.1.33 to v0.1.67

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,6 @@ repos:
         exclude: "locales"
       - id: trailing-whitespace
   - repo: https://github.com/rvben/rumdl-pre-commit
-    rev: v0.1.33
+    rev: v0.1.67
     hooks:
       - id: rumdl

--- a/docs/en/community/governance.md
+++ b/docs/en/community/governance.md
@@ -43,16 +43,16 @@ As with any project with more than one person with commit rights, there are a nu
 - Assume any expression of anger or frustration comes from a genuine place of wanting to use a BeeWare tool/library
 - Encourage other members of the community to reflect these ideals in their own communications, both inside and outside the BeeWare community
 - No Apiarist should commit their own code
-  - Exception: "Something is very broken and needs to be fixed now"
-  - Exception: BDFN (this may change in the future)
+    - Exception: "Something is very broken and needs to be fixed now"
+    - Exception: BDFN (this may change in the future)
 - All code submitted for review by a core team member should be reviewed by another team member
-  - Exception: BDFN (this may change in the future)
+    - Exception: BDFN (this may change in the future)
 - All code should pass Continuous Integration tests before being merged
-  - Exception: code that is known to be broken and needs to be committed for other reasons
-  - Exception: code in a repo with insufficient CI tests
-  - Exception: Working and committed is better than perfect and not
+    - Exception: code that is known to be broken and needs to be committed for other reasons
+    - Exception: code in a repo with insufficient CI tests
+    - Exception: Working and committed is better than perfect and not
 - Acceptance processes should be automated wherever possible
-  - This means tests, linting, spell checking, coverage, and more
+    - This means tests, linting, spell checking, coverage, and more
 
 ## Becoming an Apiarist
 

--- a/docs/en/news/posts/2017/buzz/2017-google-summer-of-code-final-report-jonas-schell.md
+++ b/docs/en/news/posts/2017/buzz/2017-google-summer-of-code-final-report-jonas-schell.md
@@ -32,12 +32,12 @@ Toga talks to native GUI frameworks, hence I had to get a good understanding abo
 - Every Toga backend wraps around a existing and unique framework. To wrap the framework you have to understand the framework.
 - “I love Python, why do I have to understand Objective C”? To effectively work on the iOS and macOS backends I had to learn the basics of Objective C – if only to read the Apple docs.
 - Toga has a lot of moving parts. There are backends, frameworks, libraries to talk to backends, libraries to perform the layout of the UI and more. I spend a good amount of time to understand all of these parts. The following is just a overview of newly acquired knowledge during GSoC:
-  - [Rubicon-ObjC](https://github.com/beeware/rubicon-objc) to talk to the iOS and macOS backends.
-  - [Colosseum](https://github.com/beeware/colosseum) to understand and fix layout problems.
-  - [<nospell>AST</nospell>](https://docs.python.org/3.6/library/ast.html) module to perform the implementation tests.
-  - The use of Design Patterns
-  - How to structure large projects.
-  - Read and understand big and complex code chunks.
+    - [Rubicon-ObjC](https://github.com/beeware/rubicon-objc) to talk to the iOS and macOS backends.
+    - [Colosseum](https://github.com/beeware/colosseum) to understand and fix layout problems.
+    - [<nospell>AST</nospell>](https://docs.python.org/3.6/library/ast.html) module to perform the implementation tests.
+    - The use of Design Patterns
+    - How to structure large projects.
+    - Read and understand big and complex code chunks.
 
 ## Other work I did
 

--- a/docs/en/news/posts/2024/buzz/february-2024-status-update.md
+++ b/docs/en/news/posts/2024/buzz/february-2024-status-update.md
@@ -15,12 +15,12 @@ February may be the shortest month, but that doesn't mean we've got any less pro
 
 - [PEP 738](https://peps.python.org/pep-0738/), adding official Android support to CPython, has been formally submitted to the Python Steering Council for approval.
 - We've started landing patches in CPython to add formal support for [iOS](https://github.com/python/cpython/issues/114099) and [Android](https://github.com/python/cpython/issues/71052). There are more patches in review, and more to come, but so far we've landed patches that:
-  - [Fix the compilation of the `grp` module on Android](https://github.com/python/cpython/pull/114876)
-  - [Disable tests that can't run on mobile platforms](https://github.com/python/cpython/pull/114889)
-  - [Refactor the CPython build system to allow for some of the oddities of iOS as a platform](https://github.com/python/cpython/pull/115120)
-  - [Add build targets for compiling iOS-compatible frameworks](https://github.com/python/cpython/pull/115390)
-  - [Correct the linking of extension modules on Android](https://github.com/python/cpython/pull/115780)
-  - [Enable the concurrent.futures tests on platforms that don't support multiprocessing](https://github.com/python/cpython/pull/115917)
+    - [Fix the compilation of the `grp` module on Android](https://github.com/python/cpython/pull/114876)
+    - [Disable tests that can't run on mobile platforms](https://github.com/python/cpython/pull/114889)
+    - [Refactor the CPython build system to allow for some of the oddities of iOS as a platform](https://github.com/python/cpython/pull/115120)
+    - [Add build targets for compiling iOS-compatible frameworks](https://github.com/python/cpython/pull/115390)
+    - [Correct the linking of extension modules on Android](https://github.com/python/cpython/pull/115780)
+    - [Enable the concurrent.futures tests on platforms that don't support multiprocessing](https://github.com/python/cpython/pull/115917)
 - We added macOS ARM64 machines to our CI capabilities for [Toga](https://github.com/beeware/toga/pull/2404) and [Briefcase](https://github.com/beeware/briefcase/pull/1652). We've officially supported ARM64 on macOS for some time, but we've been unable to test this support as part of our CI and release procedure - we've had to do ad-hoc testing on the machines we're using to develop on a day to day basis. As a result of improvements to GitHub's CI infrastructure, we're now able to perform automated testing. As part of these changes, we've also added testing for Python 3.13 (which will be released around October of this year).
 - We [added an API for detecting the displays attached to a computer, and specifying the location of windows relative to those displays](https://github.com/beeware/toga/pull/1930).
 - We [added a pluggable API for image formats](https://github.com/beeware/toga/pull/2387). With this API, any third party library that has an internal format for images can implement support so that Toga can convert to and from images in that format.

--- a/docs/en/news/posts/2024/buzz/march-2024-status-update.md
+++ b/docs/en/news/posts/2024/buzz/march-2024-status-update.md
@@ -14,18 +14,18 @@ This month, we have less to report by raw feature count - but the changes we *ha
 ## What we've done
 
 - Our primary focus this month has been making the changes to CPython needed to add support for [iOS](https://github.com/python/cpython/issues/114099) and [Android](https://github.com/python/cpython/issues/116622). We've made major progress towards this goal: all the patches required for iOS have been merged; a large number of patches have been submitted for Android, with only a small number still required. This month, we have:
-  - [Added test exclusions to support running the test suite on Android](https://github.com/python/cpython/pull/115918)
-  - [Fixed some issues with the process of building an Android `libPython`](https://github.com/python/cpython/pull/115955)
-  - [Modified `sys.platform` identification for Android so it returns "android" not <nospell>"linux"</nospell>](https://github.com/python/cpython/pull/116215)
-  - [Added an API to get device and OS information on Android](https://github.com/python/cpython/pull/116674)
-  - [Modified `ctypes` so it can load libraries on Android](https://github.com/python/cpython/pull/116379)
-  - [Modified a signals test to make it more reliable on more platforms](https://github.com/python/cpython/pull/116423)
-  - [Added a build script and instructions for Android builds](https://github.com/python/cpython/pull/116426)
-  - [Added a custom module loader so that iOS apps can load binary modules from Frameworks](https://github.com/python/cpython/pull/116454)
-  - [Modified `test_doctest` to support platforms that don't support subprocesses](https://github.com/python/cpython/pull/116758)
-  - [Modified the standard library to support iOS](https://github.com/python/cpython/pull/117052)
-  - [Added documentation for the iOS platform](https://github.com/python/cpython/pull/117057)
-  - [Corrected some additional test failures introduced on Android](https://github.com/python/cpython/pull/117299)
+    - [Added test exclusions to support running the test suite on Android](https://github.com/python/cpython/pull/115918)
+    - [Fixed some issues with the process of building an Android `libPython`](https://github.com/python/cpython/pull/115955)
+    - [Modified `sys.platform` identification for Android so it returns "android" not <nospell>"linux"</nospell>](https://github.com/python/cpython/pull/116215)
+    - [Added an API to get device and OS information on Android](https://github.com/python/cpython/pull/116674)
+    - [Modified `ctypes` so it can load libraries on Android](https://github.com/python/cpython/pull/116379)
+    - [Modified a signals test to make it more reliable on more platforms](https://github.com/python/cpython/pull/116423)
+    - [Added a build script and instructions for Android builds](https://github.com/python/cpython/pull/116426)
+    - [Added a custom module loader so that iOS apps can load binary modules from Frameworks](https://github.com/python/cpython/pull/116454)
+    - [Modified `test_doctest` to support platforms that don't support subprocesses](https://github.com/python/cpython/pull/116758)
+    - [Modified the standard library to support iOS](https://github.com/python/cpython/pull/117052)
+    - [Added documentation for the iOS platform](https://github.com/python/cpython/pull/117057)
+    - [Corrected some additional test failures introduced on Android](https://github.com/python/cpython/pull/117299)
 - [PEP 738](https://peps.python.org/pep-0738/), adding official Android support to CPython, has been formally approved by the Python Steering Council.
 - We [updated the CPython Developer Guide to describe the iOS development process](https://github.com/python/devguide/pull/1296).
 - We [improved Briefcase's handling of `stdout` for some tools](https://github.com/beeware/briefcase/pull/1687). We're hoping this will fix - or at least make it easier to diagnose - a mode of failure we've had reported for the Android emulator on Windows.


### PR DESCRIPTION
Bumps `pre-commit` hook for `rumdl-pre-commit` from v0.1.33 to v0.1.67 and ran the update against the repo.