### PR TITLE
Add AI policy to contribution guide.

### DIFF
--- a/docs/config.yml
+++ b/docs/config.yml
@@ -43,6 +43,7 @@ nav:
           - Translating content: contributing/guide/how/translate.md
           - Pull request review process: contributing/guide/next/pr-review.md
           - Release process: contributing/guide/next/release.md
+          - AI Policy: contributing/guide/policies/ai-policy.md
           - Code style guide: contributing/guide/style/code-style-guide.md
           - Documentation style guide: contributing/guide/style/docs-style-guide.md
       - Sprint guide: contributing/sprint-guide.md

--- a/docs/en/contributing/guide/policies/ai-policy.md
+++ b/docs/en/contributing/guide/policies/ai-policy.md
@@ -1,0 +1,3 @@
+<!-- rumdl-disable-file MD041 -->
+
+{% extends "contribute/policies/ai-policy.md" %}


### PR DESCRIPTION
Adds the AI policy to the contribution guide on the website.

This won't build successfully until beeware/beeware-docs-tools#210 lands.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
