### PR TITLE
Add redirect for old project pages.

### DIFF
--- a/docs/config.yml
+++ b/docs/config.yml
@@ -272,6 +272,21 @@ plugins:
     abstract_chars_count: -1
   redirects:
     redirect_maps:
+      # Toga project references
+      "toga.md": "https://toga.beeware.org/"
+      "project/toga.md": "https://toga.beeware.org/"
+      "project/projects/libraries/toga.md": "https://toga.beeware.org/"
+      # Briefcase project references
+      "briefcase.md": "https://briefcase.beeware.org/"
+      "project/briefcase.md": "https://briefcase.beeware.org/"
+      "project/projects/tools/briefcase.md": "https://briefcase.beeware.org/"
+      # Rubicon-ObjC project references
+      "rubicon.md": "https://rubicon-objc.beeware.org/"
+      "project/utilities/rubicon.md": "https://rubicon-objc.beeware.org/"
+      "project/projects/bridges/rubicon.md": "https://rubicon-objc.beeware.org/"
+      # Podium project references
+      "project/applications/podium.md": "https://github.com/beeware/podium"
+      "project/projects/applications/podium.md": "https://github.com/beeware/podium"
       # shortlinks
       "bee/briefcase-bootstraps.md": "https://briefcase.beeware.org/en/latest/reference/commands/new.html#third-party-bootstraps"
       "bee/chat.md": "https://discord.gg/AjYYm8cyQM"

--- a/docs/en/news/posts/2017/buzz/come-sprint-with-us-at-pycon-us-2017.md
+++ b/docs/en/news/posts/2017/buzz/come-sprint-with-us-at-pycon-us-2017.md
@@ -58,4 +58,4 @@ If you have any questions, just ask [myself](https://twitter.com/glasnt) or [Rus
 
 We'd love to see you there! ✨
 
-This article has been cross-posted on [glasnt.com/blog](http://glasnt.com/blog/2017/02/01/come-sprint-with-beeware.html).
+This article has been cross-posted on [glasnt.com/blog](https://glasnt.com/blog/come-sprint-with-beeware/).

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,9 @@ commands:
     translate : build_po_translations ar cs da de es fa fr it ja ko pl pt ru tr zh_CN zh_TW
     translate : update_machine_translations --soft-fail ar cs da de es fa fr it ja ko pl pt ru tr zh_CN zh_TW
     lint : pyspelling
-    lint : markdown-checker --dir {[docs]docs_dir} --func check_broken_urls --skip-domains=https://www.maxcdn.com/blog/beeware-be-sticky/,http://glasnt.com/blog/2017/02/01/come-sprint-with-beeware.html
+    # MaxCDN has been acquired and their blog no longer exists
+    # Play store has delisted Travel Tips for now..
+    lint : markdown-checker --dir {[docs]docs_dir} --func check_broken_urls --skip-domains=https://www.maxcdn.com/blog/beeware-be-sticky/,https://play.google.com/store/apps/details
     en : build_md_translations {posargs} en
     ar : build_md_translations {posargs} ar
     cs : build_md_translations {posargs} cs


### PR DESCRIPTION
Reported via mastodon - a number of the older project short links and project pages exist in current and historical PyPI pages; we need to maintain those links as redirects.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
