### PR TITLE
Add a historical shortlink for contributing/membership page.

### DIFF
--- a/docs/config.yml
+++ b/docs/config.yml
@@ -302,3 +302,4 @@ plugins:
       "community/behavior/code-of-conduct.md": "community/code-of-conduct.md"
       "community/behavior.md": "community/code-of-conduct.md"
       "community/members.md": "membership/index.md"
+      "contributing/membership.md": "membership/index.md"


### PR DESCRIPTION
The Briefcase app template historically contained a link to contributing/membership; add a redirect for that URL.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
