### PR TITLE
Add a shortlink for b/ready

### DIFF
--- a/docs/config.yml
+++ b/docs/config.yml
@@ -59,7 +59,8 @@ not_in_nav: |
   /titles.md
   /project/README.md
 
-exclude_docs: |  # This is the only way to keep the build from parsing the team bio files.
+exclude_docs:
+  | # This is the only way to keep the build from parsing the team bio files.
   !.*
   /about/team/
 
@@ -75,10 +76,10 @@ extra:
   hide_dev_links: true
   website: true
   translated: true
-  min_python_version: "3.10"  # The oldest supported Python version
-  min_python_version_tag: "310"  # The tag version of the minimum python version
-  recent_python_version: "3.13"  # The newest Python version known to work on all platforms
-  docs_python_version: "3.13"  # The version of Python required to build the documentation
+  min_python_version: "3.10" # The oldest supported Python version
+  min_python_version_tag: "310" # The tag version of the minimum python version
+  recent_python_version: "3.13" # The newest Python version known to work on all platforms
+  docs_python_version: "3.13" # The version of Python required to build the documentation
   contribution_guide_root: contributing/guide/
   social:
     - icon: fontawesome/brands/github
@@ -148,7 +149,6 @@ extra:
       link: /zh_TW/
       lang: zh-TW
 
-
 extra_css:
   - stylesheets/beeware.css
 
@@ -212,18 +212,18 @@ markdown_extensions:
       - quote
   pymdownx.blocks.details:
     types:
-      - {name: details-note, class: note}
-      - {name: details-abstract, class: abstract}
-      - {name: details-info, class: info}
-      - {name: details-tip, class: tip}
-      - {name: details-success, class: success}
-      - {name: details-question, class: question}
-      - {name: details-warning, class: warning}
-      - {name: details-failure, class: failure}
-      - {name: details-danger, class: danger}
-      - {name: details-bug, class: bug}
-      - {name: details-example, class: example}
-      - {name: details-quote, class: quote}
+      - { name: details-note, class: note }
+      - { name: details-abstract, class: abstract }
+      - { name: details-info, class: info }
+      - { name: details-tip, class: tip }
+      - { name: details-success, class: success }
+      - { name: details-question, class: question }
+      - { name: details-warning, class: warning }
+      - { name: details-failure, class: failure }
+      - { name: details-danger, class: danger }
+      - { name: details-bug, class: bug }
+      - { name: details-example, class: example }
+      - { name: details-quote, class: quote }
   pymdownx.blocks.tab:
     alternate_style: true
   pymdownx.snippets:
@@ -252,17 +252,17 @@ plugins:
       - Events
       - Resources
   autorefs:
-    resolve_closest: true  # autorefs warns of the Usage headings begin duplicates without this - we will have to assign unique ids to all of them otherwise
+    resolve_closest: true # autorefs warns of the Usage headings begin duplicates without this - we will have to assign unique ids to all of them otherwise
   macros:
     module_name: macros
     include_yaml:
-        - team: en/news/.authors.yml
+      - team: en/news/.authors.yml
   meta: {}
   rss:
     feed_title: "BeeWare: The Buzz"
     feed_description: News and events for the BeeWare project.
     match_path: "news/posts/.*"
-    use_git: false  # Forces it to read the dates from the frontmatter.
+    use_git: false # Forces it to read the dates from the frontmatter.
     date_from_meta:
       as_creation: "date"
       datetime_format: "%Y-%m-%d"
@@ -270,7 +270,7 @@ plugins:
       - categories
     feeds_filenames:
       rss_created: news/buzz/atom.xml
-#    image: images/brutus.png  # Update to a Brutus URL
+    #    image: images/brutus.png  # Update to a Brutus URL
     abstract_chars_count: -1
   redirects:
     redirect_maps:
@@ -295,9 +295,12 @@ plugins:
       "bee/coc.md": "community/code-of-conduct.md"
       "bee/join.md": "membership/index.md"
       "bee/podium.md": "https://github.com/beeware/podium"
+      "bee/ready.md": "https://github.com/orgs/beeware/projects/1/views/7"
       "bee/signup.md": "about/contact.md"
       "bee/sprint.md": "contributing/sprint-guide.md"
       "bee/sprints.md": "contributing/sprint-guide.md"
+      # Short shortlinks
+      "b/ready.md": "https://github.com/orgs/beeware/projects/1/views/7"
       "b/sprints.md": "contributing/sprint-guide.md"
       "b/sprint.md": "contributing/sprint-guide.md"
       # Historical links of significance


### PR DESCRIPTION
Adds short links for b/ready and bee/ready to point at the project board.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
