### PR TITLE
Fix: Mobile margins on news pages

### DIFF
--- a/docs/en/stylesheets/beeware.css
+++ b/docs/en/stylesheets/beeware.css
@@ -565,8 +565,8 @@ h1 .news {
 }
 
 .md-sidebar--primary:is([hidden]) ~ .md-content.md-content--post {
-    margin-left: 0;
-    margin-right: 0;
+    margin-left: 6.7%;
+    margin-right: 6.7%;
     max-width: fit-content;
 }
 


### PR DESCRIPTION
This change fixes #770 by addressing an issue where news pages override the default content margins using a highly specific CSS rule. By restoring the same horizontal margins used by standard content pages, this update prevents the insufficient horizontal spacing seen on narrow viewports, ultimately improving the readability of news posts on mobile devices.

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
Assisted-by: ChatGPT