### PR TITLE
chore: Add a 7 day cooldown to dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,13 +12,19 @@ updates:
     directory: "/"
     patterns: ["*"]
     multi-ecosystem-group: "dependencies"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/"
     patterns: ["*"]
     multi-ecosystem-group: "dependencies"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pre-commit"
     directory: "/"
     patterns: ["*"]
     multi-ecosystem-group: "dependencies"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Adds a 7-day `cooldown` to each entry in `.github/dependabot.yml`
(github-actions, pip, and pre-commit), mirroring the configuration
already in place in `beeware/.github`.

Dependabot currently upgrades packages to the newest available version
immediately on publication, which leaves no window for a malicious
release to be identified before it is rolled out. A cooldown introduces
that window and aligns this repo with the project's supply-chain
hardening practice.

Fixes #804.

## PR Checklist:
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [x] This PR was generated or assisted using an AI tool
Assisted-by: Claude Opus 4.5