### PR TITLE
fix(docs): missing dollar sign in Fan membership price

### DIFF
--- a/docs/en/membership/index.md
+++ b/docs/en/membership/index.md
@@ -16,7 +16,7 @@ We have several levels of membership available, to fit a wide range of financial
 
 If you'd like to provide basic support of the BeeWare project, we offer three tiers of support:
 
-- **Fan**: 5/month
+- **Fan**: $5/month
 - **Enthusiast**: $10/month
 - **Super-Enthusiast**: $15/month
 


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

This PR added a missing dollar "$" sign from the Fan membership pricing on the sponsors page.

before ---

<img width="625" height="276" alt="image" src="https://github.com/user-attachments/assets/bab20e52-e8dd-44d6-b297-d9c5e4aabf02" />


after ---

<img width="625" height="276" alt="image" src="https://github.com/user-attachments/assets/f5126ac4-de76-40b1-b71f-d254d577b84b" />


## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
<!-- update or delete the next line to reflect your usage -->
